### PR TITLE
Fixed a compilation error where macro definitions could not be found

### DIFF
--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -106,13 +106,8 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
         std::cerr << "kiwi Server version: " << Kkiwi_VERSION << " bits=" << (sizeof(void*) == 8 ? 64 : 32)
                   << std::endl;
         std::cerr << "kiwi Server Build Type: " << Kkiwi_BUILD_TYPE << std::endl;
-#if defined(Kkiwi_BUILD_DATE)
         std::cerr << "kiwi Server Build Date: " << Kkiwi_BUILD_DATE << std::endl;
-#endif
-#if defined(Kkiwi_GIT_COMMIT_ID)
         std::cerr << "kiwi Server Build GIT SHA: " << Kkiwi_GIT_COMMIT_ID << std::endl;
-#endif
-
         std::exit(0);
         break;
       }
@@ -201,7 +196,7 @@ bool KiwiDB::Init() {
     PREPL.SetMasterAddr(g_config.master_ip.ToString().c_str(), g_config.master_port.load());
   }
 
-  event_server_ =std::make_unique<net::EventServer<std::shared_ptr<PClient>>>(num);
+  event_server_ = std::make_unique<net::EventServer<std::shared_ptr<PClient>>>(num);
 
   event_server_->SetRwSeparation(true);
 

--- a/src/kiwi.h
+++ b/src/kiwi.h
@@ -22,6 +22,14 @@
 #  define Kkiwi_BUILD_TYPE "RELEASE"
 #endif
 
+#ifndef Kkiwi_GIT_COMMIT_ID
+#  define Kkiwi_GIT_COMMIT_ID "unknown"
+#endif
+
+#ifndef Kkiwi_BUILD_DATE
+#  define Kkiwi_BUILD_DATE "unknown"
+#endif
+
 namespace kiwi {
 class PRaft;
 }  // namespace kiwi
@@ -58,9 +66,7 @@ class KiwiDB final {
     event_server_->SendPacket(client, std::move(msg));
   }
 
-  inline void CloseConnection(const std::shared_ptr<kiwi::PClient>& client) {
-    event_server_->CloseConnection(client);
-  }
+  inline void CloseConnection(const std::shared_ptr<kiwi::PClient>& client) { event_server_->CloseConnection(client); }
 
   void TCPConnect(
       const net::SocketAddr& addr,


### PR DESCRIPTION
修复没有使用 `build.sh` 编译导致的 宏定义找不到错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility of build information by always displaying the build date and GIT commit ID when the server runs.
	- Introduced new definitions for better tracking of build metadata.

- **Bug Fixes**
	- Minor formatting adjustments for improved consistency in server initialization.

- **Refactor**
	- Reformatted the `CloseConnection` method for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->