### PR TITLE
fix: add mutex to support concurrency `raft.cluster join`

### DIFF
--- a/src/praft/praft.cc
+++ b/src/praft/praft.cc
@@ -532,6 +532,8 @@ int PRaft::ProcessClusterRemoveCmdResponse(PClient* client, const char* start, i
 }
 
 butil::Status PRaft::AddPeer(const std::string& peer) {
+  std::unique_lock<std::mutex> lck(add_peer_mutex_);
+
   if (!node_) {
     ERROR_LOG_AND_STATUS("Node is not initialized");
   }

--- a/src/praft/praft.cc
+++ b/src/praft/praft.cc
@@ -532,11 +532,11 @@ int PRaft::ProcessClusterRemoveCmdResponse(PClient* client, const char* start, i
 }
 
 butil::Status PRaft::AddPeer(const std::string& peer) {
-  std::unique_lock<std::mutex> lck(add_peer_mutex_);
-
   if (!node_) {
-    ERROR_LOG_AND_STATUS("Node is not initialized");
+    return ERROR_LOG_AND_STATUS("Node is not initialized");
   }
+
+  std::unique_lock<std::mutex> lck(change_peer_mutex_);
 
   braft::SynchronizedClosure done;
   node_->add_peer(peer, &done);
@@ -554,6 +554,8 @@ butil::Status PRaft::RemovePeer(const std::string& peer) {
   if (!node_) {
     return ERROR_LOG_AND_STATUS("Node is not initialized");
   }
+
+  std::unique_lock<std::mutex> lck(change_peer_mutex_);
 
   braft::SynchronizedClosure done;
   node_->remove_peer(peer, &done);

--- a/src/praft/praft.h
+++ b/src/praft/praft.h
@@ -171,6 +171,9 @@ class PRaft : public braft::StateMachine {
   int db_id_ = 0;                      // db_id
 
   bool is_node_first_start_up_ = true;
+
+  // Concurrency `raft.cluster join` will throw an error, so use a mutex for restriction.
+  std::mutex add_peer_mutex_;
 };
 
 }  // namespace kiwi

--- a/src/praft/praft.h
+++ b/src/praft/praft.h
@@ -173,7 +173,7 @@ class PRaft : public braft::StateMachine {
   bool is_node_first_start_up_ = true;
 
   // Concurrency `raft.cluster join` will throw an error, so use a mutex for restriction.
-  std::mutex add_peer_mutex_;
+  std::mutex change_peer_mutex_;
 };
 
 }  // namespace kiwi


### PR DESCRIPTION
> 支持并发 confchange：jepsen 会同时启动4个容器做 raft.cluster join，目前会出现部分节点join失败

关联issue：https://github.com/arana-db/kiwi/issues/25
补充报错信息：`(error) ERR -ERR Failed to add peer: Doing another configuration change`
报错位置: https://github.com/pikiwidb/braft/blob/master/src/braft/node.cpp#L882
修复方案：添加一个 mutex 限制并发

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread safety in peer management with mutex locking during peer addition and removal.
  
- **Bug Fixes**
	- Improved error handling for uninitialized nodes, returning error status instead of logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->