### PR TITLE
fix: String2int error

### DIFF
--- a/src/pstd/pstd_string.h
+++ b/src/pstd/pstd_string.h
@@ -67,6 +67,21 @@ int String2int(const char* s, size_t slen, T* val) {
   }
 }
 
+/* Convert a string into a integral. Returns 1 if the all char of string could be parsed
+ * into a integer, 0 otherwise. The value will be set to
+ * the parsed value when appropriate. */
+template <std::integral T>
+int String2intStrict(const char* s, size_t slen, T* val) {
+  auto [ptr, ec] = std::from_chars(s, s + slen, *val);
+  if (ec != std::errc()) {
+    return 0;
+  }
+  if (ptr != s + slen) {
+    return 0;
+  }
+  return 1;
+}
+
 template <std::integral T>
 inline int String2int(const std::string& s, T* val) {
   return String2int(s.data(), s.size(), val);

--- a/src/storage/include/storage/util.h
+++ b/src/storage/include/storage/util.h
@@ -17,6 +17,7 @@ namespace storage {
 
 int Int64ToStr(char* dst, size_t dstlen, int64_t svalue);
 int StrToInt64(const char* s, size_t slen, int64_t* value);
+int StrToInt64Strict(const char* s, size_t slen, int64_t* value);
 int StringMatch(const char* pattern, uint64_t pattern_len, const char* string, uint64_t string_len, int nocase);
 int StrToLongDouble(const char* s, size_t slen, long double* ldval);
 int LongDoubleToStr(long double ldval, std::string* value);

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -290,7 +290,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
         ParsedBaseDataValue parsed_internal_value(&old_value);
         parsed_internal_value.StripSuffix();
         int64_t ival = 0;
-        if (StrToInt64(old_value.data(), old_value.size(), &ival) == 0) {
+        if (StrToInt64Strict(old_value.data(), old_value.size(), &ival) == 0) {
           return Status::Corruption("hash value is not an integer");
         }
         if ((value >= 0 && LLONG_MAX - value < ival) || (value < 0 && LLONG_MIN - value > ival)) {

--- a/src/storage/src/util.cc
+++ b/src/storage/src/util.cc
@@ -37,6 +37,11 @@ int Int64ToStr(char* dst, size_t dstlen, int64_t svalue) { return pstd::Ll2strin
  * the parsed value when appropriate. */
 int StrToInt64(const char* s, size_t slen, int64_t* value) { return pstd::String2int(s, slen, value); }
 
+/* Convert a string into a long long. Returns 1 if all char of string could be parsed
+ * into a (non-overflowing) long long, 0 otherwise. The value will be set to
+ * the parsed value when appropriate. */
+int StrToInt64Strict(const char* s, size_t slen, int64_t* value) { return pstd::String2intStrict(s, slen, value); }
+
 /* Glob-style pattern matching. */
 int StringMatch(const char* pattern, uint64_t pattern_len, const char* str, uint64_t string_len, int nocase) {
   return pstd::StringMatchLen(pattern, static_cast<int32_t>(pattern_len), str, static_cast<int32_t>(string_len),


### PR DESCRIPTION
解决issue https://github.com/arana-db/kiwi/issues/55
原来的String2int判断逻辑是通过错误码来进行判断，但是根据函数解释，"11 "会被认为转换成功，于是修改判断逻辑，改为是否都匹配上了，即ptr与s+slen的比较
![image](https://github.com/user-attachments/assets/b9cf0dbd-74b7-4a86-b5e6-fb5b483eb614)

修改后测试通过
![image](https://github.com/user-attachments/assets/bee1c396-1484-4c6f-97ab-aaac4b68964d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced stricter string-to-integer conversion methods, enhancing validation for parsing.
	- Added new methods for scanning and renaming hash keys in the Redis implementation.
- **Bug Fixes**
	- Improved error handling for hash operations, providing more specific error messages related to stale values and type mismatches.
- **Chores**
	- General code cleanup for improved readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->