### PR TITLE
fix: ci run on macos-12

### DIFF
--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -24,7 +24,7 @@ jobs:
         run: make check-format
 
   build_on_macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: check_format
 
     steps:


### PR DESCRIPTION
fix macos TCL test error problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the macOS environment for the build process to a more specific version (`macos-12`) in the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->