### PR TITLE
fix: add cstdint header

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,6 @@ Checks:     '
 WarningsAsErrors: '*'
 # HeaderFilterRegex: '(|/src|/src/net|/src/pstd|/src/storage)/include'
 # HeaderFilterRegex: '/src/(net|storage|pstd)/include'
-AnalyzeTemporaryDtors: true
 
 #### Disabled checks and why: #####
 #

--- a/src/pstd/pstd_string.h
+++ b/src/pstd/pstd_string.h
@@ -37,6 +37,7 @@
 #include <charconv>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace pstd {
 


### PR DESCRIPTION
Add the cstdint header file to enable normal compilation in the Linux environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added an include directive for `<cstdint>` to enhance type safety and clarity in the code.
	- Updated the `.clang-tidy` configuration to disable certain checks and improve code analysis management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->