### PR TITLE
fix: fix addWriteEvent error

### DIFF
--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -16,6 +16,7 @@
 #include "callback_function.h"
 #include "config.h"
 #include "io_thread.h"
+#include "net_event.h"
 
 #if defined(HAVE_EPOLL)
 
@@ -255,7 +256,7 @@ void ThreadManager<T>::SendPacket(const T &conn, std::string &&msg) {
 
   connPtr->netEvent_->SendPacket(std::move(msg));
 
-  if (connPtr->netEvent_->CheckSetFlag(0)) {
+  if (connPtr->netEvent_->CheckSetFlag(static_cast<uint8_t>(IOSocketFlag::WRITE))) {
     if (rwSeparation_) {
       writeThread_->SetWriteEvent(connId, connPtr->fd_);
     } else {


### PR DESCRIPTION
error sush as:
![image](https://github.com/user-attachments/assets/e1a4e070-8c6e-43d2-ba89-c20056c66acf)

This errno error code indicates that the write event already exists.
This error caused the single-core CPU to spike (because the flag bit was not successfully set, the write event was not successfully deleted).

Set the correct flag bit, and this problem will be solved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced socket handling for improved network communication.
- **Bug Fixes**
	- Refined logic for checking socket readiness, ensuring more reliable packet sending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->