### PR TITLE
fix: fix run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Kiwi is compiled by default in release mode, which does not support debugging. I
 ## Run
 
 ```bash
-./bin/kiwi ./etc/conf/Kiwi.conf
+./bin/kiwi ./etc/conf/kiwi.conf
 ```
 
 ## Support module for write your own extensions

--- a/README_CN.md
+++ b/README_CN.md
@@ -36,7 +36,7 @@ Kiwi 默认以 release 模式编译，不支持调试。如果需要调试，请
 ## 运行
 
 ```bash
-./bin/kiwi ./etc/conf/Kiwi.conf
+./bin/kiwi ./etc/conf/kiwi.conf
 ```
 
 ## 与 Redis 完全兼容


### PR DESCRIPTION
fix run command.
Change to the correct configuration file name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated configuration file path in the "Run" section of both English and Chinese README files from `Kiwi.conf` to `kiwi.conf` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->