### PR TITLE
fix: multi-thread writing data error

### DIFF
--- a/src/net/base_event.h
+++ b/src/net/base_event.h
@@ -43,6 +43,7 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
   const static int EVENT_WRITE;
   const static int EVENT_ERROR;
   const static int EVENT_HUB;
+  const static int EVENT_NULL;
 
   BaseEvent(const std::shared_ptr<NetEvent> &listen, int8_t mode, int8_t type)
       : listen_(listen), mode_(mode), type_(type){};

--- a/src/net/epoll_event.cc
+++ b/src/net/epoll_event.cc
@@ -18,6 +18,7 @@ const int BaseEvent::EVENT_READ = EPOLLIN;
 const int BaseEvent::EVENT_WRITE = EPOLLOUT;
 const int BaseEvent::EVENT_ERROR = EPOLLERR;
 const int BaseEvent::EVENT_HUB = EPOLLHUP;
+const int BaseEvent::EVENT_NULL = 0;
 
 bool EpollEvent::Init() {
   evFd_ = epoll_create1(0);
@@ -67,22 +68,23 @@ void EpollEvent::AddWriteEvent(uint64_t id, int fd) {
       ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add RW error errno:{}", id, EvFd(), fd, errno);
     }
   } else {  // If it is a write multiplex, add the event
-    if (epoll_ctl(EvFd(), EPOLL_CTL_ADD, fd, &ev) == -1) {
+    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
       ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add W error errno:{}", id, EvFd(), fd, errno);
     }
   }
 }
 
 void EpollEvent::DelWriteEvent(uint64_t id, int fd) {
-  if (mode_ & EVENT_MODE_READ) {  // If it is a read multiplex, modify the event to read
-    struct epoll_event ev {};
+  struct epoll_event ev {};
+  ev.data.u64 = id;
+  if (mode_ & EVENT_MODE_READ) {  // If it is a read multiplex, modify the event to rea
     ev.events = EVENT_READ;
-    ev.data.u64 = id;
     if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
       ERROR("DelWriteEvent id:{},EvFd:{},fd:{}, EPOLL_CTL_MOD error errno:{}", id, EvFd(), fd, errno);
     }
   } else {
-    if (epoll_ctl(EvFd(), EPOLL_CTL_DEL, fd, nullptr) == -1) {
+    ev.events = BaseEvent::EVENT_NULL;
+    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
       ERROR("DelWriteEvent id:{},EvFd:{},fd:{}, EPOLL_CTL_DEL error errno:{}", id, EvFd(), fd, errno);
     }
   }
@@ -159,7 +161,6 @@ void EpollEvent::DoRead(const epoll_event &event, const std::shared_ptr<Connecti
   } else if (conn) {
     std::string readBuff;
     int ret = conn->netEvent_->OnReadable(conn, &readBuff);
-    DEBUG("DoRead ret:{}; msg:{}", ret, readBuff);
     if (ret == NE_ERROR) {
       DoError(event, "read error,errno: " + std::to_string(errno));
       return;
@@ -179,11 +180,8 @@ void EpollEvent::DoWrite(const epoll_event &event, const std::shared_ptr<Connect
     DoError(event, "write error,errno: " + std::to_string(errno));
     return;
   }
-  if (ret == NE_OK) {  // If the data is sent, delete the write event
-    if (conn->netEvent_->CheckDecFlag(static_cast<uint8_t>(IOSocketFlag::WRITE))) {
-      DelWriteEvent(event.data.u64, conn->fd_);
-      conn->netEvent_->UnlockFlag();
-    }
+  if (ret == NE_OK) {  // If the write is successful, delete the write event
+    DelWriteEvent(event.data.u64, conn->fd_);
   }
 }
 

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -16,6 +16,7 @@ const int BaseEvent::EVENT_READ = EVFILT_READ;
 const int BaseEvent::EVENT_WRITE = EVFILT_WRITE;
 const int BaseEvent::EVENT_ERROR = EV_ERROR;
 const int BaseEvent::EVENT_HUB = EV_EOF;
+const int BaseEvent::EVENT_NULL = EVFILT_USER;
 
 bool KqueueEvent::Init() {
   evFd_ = kqueue();

--- a/src/net/net_event.h
+++ b/src/net/net_event.h
@@ -28,11 +28,6 @@ enum class NetListen {
   LISTEN_ERROR,
 };
 
-enum class IOSocketFlag {
-  READ = 1,
-  WRITE = 1 << 1,
-};
-
 // abstraction of all networks
 class NetEvent {
  public:
@@ -56,17 +51,10 @@ class NetEvent {
 
   virtual void Close() = 0;
 
-  virtual bool CheckSetFlag(uint8_t flag) { return false; }
-  virtual bool CheckDecFlag(uint8_t flag) { return false; }
-
   inline int Fd() const { return fd_.load(); }
-  inline void LockFlag() { flagMutex_.lock(); }
-  inline void UnlockFlag() { flagMutex_.unlock(); }
 
  protected:
   std::atomic<int> fd_ = 0;
-  std::atomic<uint8_t> flag_ = 0;
-  std::mutex flagMutex_;
 };
 
 }  // namespace net

--- a/src/net/stream_socket.cc
+++ b/src/net/stream_socket.cc
@@ -16,6 +16,7 @@ int StreamSocket::OnReadable(const std::shared_ptr<Connection> &conn, std::strin
 int StreamSocket::OnWritable() {
   if (sendData_.empty()) {
     if (!writeQueue_.Pop(sendData_)) {  // no data to send
+      writeReady_.store(false);
       return NE_OK;
     }
   }
@@ -34,6 +35,7 @@ int StreamSocket::OnWritable() {
     sendData_.clear();
     // determine if there is still data in the queue
     if (writeQueue_.Empty()) {
+      writeReady_.store(false);
       return NE_OK;
     }
   }
@@ -43,10 +45,9 @@ int StreamSocket::OnWritable() {
 bool StreamSocket::SendPacket(std::string &&msg) {
   bool sendOver;
   do {
-    sendOver = writeQueue_.Push(std::move(msg));
+    sendOver = writeQueue_.Push(msg);
   } while (!sendOver);
-
-  return true;
+  return !writeReady_.exchange(true);
 }
 
 // Read data from the socket
@@ -74,24 +75,6 @@ int StreamSocket::Read(std::string *readBuff) {
   }
 
   return NE_OK;
-}
-
-bool StreamSocket::CheckSetFlag(uint8_t flag) {
-  if (!(flag_.load() & flag) && !writeQueue_.Empty()) {
-    LockFlag();
-    flag_ |= flag;
-    return true;  // need add write flag
-  }
-  return false;
-}
-
-bool StreamSocket::CheckDecFlag(uint8_t flag) {
-  if ((flag_.load() & flag) && writeQueue_.Empty()) {
-    LockFlag();
-    flag_ &= ~flag;
-    return true;  // need dec write flag
-  }
-  return false;
 }
 
 }  // namespace net

--- a/src/net/stream_socket.h
+++ b/src/net/stream_socket.h
@@ -33,9 +33,6 @@ class StreamSocket : public BaseSocket {
 
   int Read(std::string *readBuff);
 
-  bool CheckSetFlag(uint8_t flag) override;
-  bool CheckDecFlag(uint8_t flag) override;
-
  private:
   const int readBuffSize_ = 4 * 1024;  // read from socket buff size 4K
 
@@ -44,6 +41,8 @@ class StreamSocket : public BaseSocket {
   LockFreeRingBuffer<std::string> writeQueue_{8};  // write data queue
 
   size_t sendPos_ = 0;  // send data buff pos
+
+  std::atomic<bool> writeReady_ = false;  // write ready flag
 };
 
 }  // namespace net

--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -159,6 +159,9 @@ void ThreadManager<T>::OnNetEventCreate(int fd, const std::shared_ptr<Connection
     connections_.emplace(connId, std::make_pair(t, conn));
   }
   readThread_->AddNewEvent(connId, fd, BaseEvent::EVENT_READ);
+  if (writeThread_) {
+    writeThread_->AddNewEvent(connId, fd, BaseEvent::EVENT_NULL);  // add null event to write_thread epoll
+  }
 
   onCreate_(connId, t, conn->addr_);
 }
@@ -254,14 +257,10 @@ void ThreadManager<T>::SendPacket(const T &conn, std::string &&msg) {
   }
 
   connPtr->netEvent_->SendPacket(std::move(msg));
-
-  if (connPtr->netEvent_->CheckSetFlag(0)) {
-    if (rwSeparation_) {
-      writeThread_->SetWriteEvent(connId, connPtr->fd_);
-    } else {
-      readThread_->SetWriteEvent(connId, connPtr->fd_);
-    }
-    connPtr->netEvent_->UnlockFlag();
+  if (rwSeparation_) {
+    writeThread_->SetWriteEvent(connId, connPtr->fd_);
+  } else {
+    readThread_->SetWriteEvent(connId, connPtr->fd_);
   }
 }
 

--- a/src/pstd/lock_free_ring_buffer.h
+++ b/src/pstd/lock_free_ring_buffer.h
@@ -42,12 +42,11 @@ class LockFreeRingBuffer {
     size_t current_tail = tail_.load(std::memory_order_relaxed);
     size_t next_tail = (current_tail + 1) & (capacity_ - 1);
 
-    if (next_tail == head_.load(std::memory_order_acquire)) {
+    if (!tail_.compare_exchange_strong(current_tail, next_tail, std::memory_order_acq_rel)) {
       // queue is full
       return false;
     }
-
-    buffer_[current_tail] = std::forward<U>(item);  // 使用完美转发
+    buffer_[current_tail] = std::forward<U>(item);
     tail_.store(next_tail, std::memory_order_release);
     return true;
   }
@@ -60,7 +59,7 @@ class LockFreeRingBuffer {
       return false;
     }
 
-    item = std::move(buffer_[current_head]);  // 移动数据
+    item = std::move(buffer_[current_head]);
     head_.store((current_head + 1) & (capacity_ - 1), std::memory_order_release);
     return true;
   }


### PR DESCRIPTION
修复之前的多线程写入数据,修改epoll的flag 导致的写入失效问题

如果有同学在测试中发现还有问题,欢迎提 issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new constant `EVENT_NULL` for enhanced event handling in the network system.
	- Added a `writeReady_` state in the `StreamSocket` class to improve management of write operations.

- **Bug Fixes**
	- Streamlined event management logic in the `ThreadManager` class for better handling of network events.

- **Refactor**
	- Simplified the `NetEvent` and `StreamSocket` classes by removing unnecessary flag-checking methods and related variables.
	- Enhanced atomicity in the `Push` method of the `LockFreeRingBuffer` class for improved thread safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->