### PR TITLE
fix: update ci macos version

### DIFF
--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -24,7 +24,7 @@ jobs:
         run: make check-format
 
   build_on_macos:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: check_format
 
     steps:

--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -24,15 +24,11 @@ jobs:
         run: make check-format
 
   build_on_macos:
-    runs-on: macos-14
+    runs-on: macos-13
     needs: check_format
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Xcode Command Line Tools
-        run: |
-          xcode-select --install
 
       - name: Build
         run: |

--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install Xcode Command Line Tools
         run: |
-        xcode-select --install
+          xcode-select --install
 
       - name: Build
         run: |

--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Xcode Command Line Tools
+        run: |
+        xcode-select --install
+
       - name: Build
         run: |
           brew install autoconf

--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -24,7 +24,7 @@ jobs:
         run: make check-format
 
   build_on_macos:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: check_format
 
     steps:

--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -328,8 +328,8 @@ bool ThreadManager<T>::CreateWriteThread() {
 }
 
 template <typename T>
-requires HasSetFdFunction<T>
-uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd, const std::shared_ptr<Connection> &conn) {
+requires HasSetFdFunction<T> uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd,
+                                                                     const std::shared_ptr<Connection> &conn) {
   auto connId = getConnId();
   if constexpr (IsPointer_v<T>) {
     t->SetConnId(connId);

--- a/src/pstd/pstd_string.h
+++ b/src/pstd/pstd_string.h
@@ -35,9 +35,9 @@
 #pragma once
 
 #include <charconv>
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace pstd {
 


### PR DESCRIPTION
macos 12 ci 在github已被弃用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the macOS runner version in the GitHub Actions workflow for improved build and test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->