### PR TITLE
fix: lockfree queue push test error

### DIFF
--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -328,8 +328,8 @@ bool ThreadManager<T>::CreateWriteThread() {
 }
 
 template <typename T>
-requires HasSetFdFunction<T>
-uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd, const std::shared_ptr<Connection> &conn) {
+requires HasSetFdFunction<T> uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd,
+                                                                     const std::shared_ptr<Connection> &conn) {
   auto connId = getConnId();
   if constexpr (IsPointer_v<T>) {
     t->SetConnId(connId);

--- a/src/pstd/lock_free_ring_buffer.h
+++ b/src/pstd/lock_free_ring_buffer.h
@@ -41,8 +41,7 @@ class LockFreeRingBuffer {
   bool Push(U&& item) {
     size_t current_tail = tail_.load(std::memory_order_relaxed);
     size_t next_tail = (current_tail + 1) & (capacity_ - 1);
-
-    if (!tail_.compare_exchange_strong(current_tail, next_tail, std::memory_order_acq_rel)) {
+    if (next_tail == head_.load(std::memory_order_acquire)) {
       // queue is full
       return false;
     }

--- a/src/pstd/pstd_string.h
+++ b/src/pstd/pstd_string.h
@@ -35,9 +35,9 @@
 #pragma once
 
 #include <charconv>
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace pstd {
 

--- a/src/pstd/tests/lock_free_ring_buffer_test.cc
+++ b/src/pstd/tests/lock_free_ring_buffer_test.cc
@@ -48,7 +48,7 @@ TEST_F(LockFreeRingBufferTest, SingleThread) {
 
 TEST_F(LockFreeRingBufferTest, MultipleThread) {
   LockFreeRingBuffer<int> ring_buffer(10);
-  const int SIZE = 1000;
+  const int SIZE = 10000;
   std::thread producer([&ring_buffer]() {
     for (int i = 0; i < SIZE; ++i) {
       while (!ring_buffer.Push(i)) {
@@ -60,10 +60,10 @@ TEST_F(LockFreeRingBufferTest, MultipleThread) {
     int i = 0;
     while (i < SIZE) {
       int item;
-      if (ring_buffer.Pop(item)) {
-        ASSERT_EQ(item, i);
-        ++i;
+      while (!ring_buffer.Pop(item)) {
       }
+      ASSERT_EQ(item, i);
+      ++i;
     }
   });
   producer.join();


### PR DESCRIPTION
修复无锁队列push数据错误
上次修改后没有跑测试,导致一个错误没有发现

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for handling full queue conditions in the ring buffer, ensuring items are only added when space is available.
  
- **Tests**
	- Increased the iteration count in the `MultipleThread` test case to enhance testing coverage.
	- Updated consumer thread logic to continuously attempt to pop items until successful, improving reliability of item retrieval.

- **Chores**
	- Refined method declaration syntax in the `ThreadManager` class for better clarity.
	- Updated header inclusions in the `pstd_string` file for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->