### PR TITLE
feat: read configuration 

### DIFF
--- a/etc/conf/kiwi.conf
+++ b/etc/conf/kiwi.conf
@@ -345,7 +345,7 @@ rocksdb-level0-stop-writes-trigger 36
 rocksdb-ttl-second 604800
 # default 86400 * 3
 rocksdb-periodic-second 259200;
-0
+
 ############################### RAFT ###############################
 use-raft no
 # Braft relies on brpc to communicate via the default port number plus the port offset

--- a/src/config.cc
+++ b/src/config.cc
@@ -67,12 +67,22 @@ Status BaseValue::Set(const std::string& value, bool init_stage) {
 }
 
 Status StringValue::SetValue(const std::string& value) {
+  *values_ = value;
+  return Status::OK();
+}
+
+Status StringValueArray::SetValue(const std::string& value) {
   auto values = SplitString(value, delimiter_);
-  if (values.size() != values_.size()) {
-    return Status::InvalidArgument("The number of parameters does not match.");
+  if (!values_.empty()) {  // if the value_ is not empty, check the number of parameters
+    if (values.size() != values_.size()) {
+      return Status::InvalidArgument("The number of parameters does not match.");
+    }
+  } else {  // if the value_ is empty, resize the value_ to the size of the values
+    values_.resize(values.size());
   }
-  for (int i = 0; i < values_.size(); i++) {
-    *values_[i] = std::move(values[i]);
+
+  for (int i = 0; i < values.size(); i++) {
+    values_[i] = std::move(values[i]);
   }
   return Status::OK();
 }
@@ -103,18 +113,35 @@ Status NumberValue<T>::SetValue(const std::string& value) {
   return Status::OK();
 }
 
+Status MemorySize::SetValue(const std::string& value) {
+  auto status = NumberValue<size_t>::SetValue(value);
+  if (!status.ok()) {
+    return status;
+  }
+  char unit = value[value.size() - 1];
+  if (unit == 'k' || unit == 'K') {
+    *value_ *= (1 << 10);
+  } else if (unit == 'm' || unit == 'M') {
+    *value_ *= (1 << 20);
+  } else if (unit == 'g' || unit == 'G') {
+    *value_ *= (1 << 30);
+  }
+
+  return Status::OK();
+}
+
 PConfig::PConfig() {
-  AddBool("redis-compatible-mode", &CheckYesNo, true, {&redis_compatible_mode});
+  AddBool("redis-compatible-mode", &CheckYesNo, true, &redis_compatible_mode);
   AddBool("daemonize", &CheckYesNo, false, &daemonize);
-  AddString("ip", false, {&ip});
+  AddString("ip", false, &ip);
   AddNumberWithLimit<uint16_t>("port", false, &port, PORT_LIMIT_MIN, PORT_LIMIT_MAX);
   AddNumber("raft-port-offset", true, &raft_port_offset);
   AddNumber("timeout", true, &timeout);
-  AddString("db-path", false, {&db_path});
-  AddStringWithFunc("loglevel", &CheckLogLevel, false, {&log_level});
-  AddString("logfile", false, {&log_dir});
+  AddString("db-path", false, &db_path);
+  AddStringWithFunc("loglevel", &CheckLogLevel, false, &log_level);
+  AddString("logfile", false, &log_dir);
   AddNumberWithLimit<size_t>("databases", false, &databases, 1, DBNUMBER_MAX);
-  AddString("requirepass", true, {&password});
+  AddString("requirepass", true, &password);
   AddNumber("maxclients", true, &max_clients);
   AddNumberWithLimit<uint32_t>("worker-threads", false, &worker_threads_num, 1, THREAD_MAX);
   AddNumberWithLimit<uint32_t>("slave-threads", false, &worker_threads_num, 1, THREAD_MAX);
@@ -124,7 +151,7 @@ PConfig::PConfig() {
   AddNumberWithLimit<int32_t>("fast-cmd-threads-num", false, &fast_cmd_threads_num, 1, THREAD_MAX);
   AddNumberWithLimit<int32_t>("slow-cmd-threads-num", false, &slow_cmd_threads_num, 1, THREAD_MAX);
   AddNumber("max-client-response-size", true, &max_client_response_size);
-  AddString("runid", false, {&run_id});
+  AddString("runid", false, &run_id);
   AddNumber("small-compaction-threshold", true, &small_compaction_threshold);
   AddNumber("small-compaction-duration-threshold", true, &small_compaction_duration_threshold);
   AddBool("use-raft", &CheckYesNo, false, &use_raft);

--- a/src/config.h
+++ b/src/config.h
@@ -64,8 +64,7 @@ class BaseValue {
 class StringValue : public BaseValue {
  public:
   StringValue(const std::string& key, CheckFunc check_func_ptr, bool rewritable, std::string* value_ptr_vec)
-      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec) {
-  }
+      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec) {}
   ~StringValue() override = default;
 
   std::string Value() const override { return *values_; };
@@ -80,8 +79,7 @@ class StringValueArray : public BaseValue {
  public:
   StringValueArray(const std::string& key, CheckFunc check_func_ptr, bool rewritable,
                    std::vector<std::string>& value_ptr_vec, char delimiter = ' ')
-      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec), delimiter_(delimiter) {
-  }
+      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec), delimiter_(delimiter) {}
   ~StringValueArray() override = default;
 
   std::string Value() const override { return pstd::StringConcat(values_, delimiter_); };

--- a/src/config.h
+++ b/src/config.h
@@ -17,13 +17,13 @@
 #include <map>
 #include <memory>
 #include <unordered_map>
+#include <utility>
 #include <vector>
-
-#include "rocksdb/options.h"
-#include "rocksdb/table.h"
 
 #include "common.h"
 #include "config_parser.h"
+#include "rocksdb/options.h"
+#include "rocksdb/table.h"
 
 namespace kiwi {
 
@@ -35,8 +35,8 @@ extern PConfig g_config;
 
 class BaseValue {
  public:
-  BaseValue(const std::string& key, CheckFunc check_func_ptr, bool rewritable = false)
-      : key_(key), custom_check_func_ptr_(check_func_ptr), rewritable_(rewritable) {}
+  BaseValue(std::string key, CheckFunc check_func_ptr, bool rewritable = false)
+      : key_(std::move(key)), custom_check_func_ptr_(std::move(check_func_ptr)), rewritable_(rewritable) {}
 
   virtual ~BaseValue() = default;
 
@@ -63,19 +63,33 @@ class BaseValue {
 
 class StringValue : public BaseValue {
  public:
-  StringValue(const std::string& key, CheckFunc check_func_ptr, bool rewritable,
-              const std::vector<std::string*>& value_ptr_vec, char delimiter = ' ')
-      : BaseValue(key, check_func_ptr, rewritable), values_(value_ptr_vec), delimiter_(delimiter) {
-    assert(!values_.empty());
+  StringValue(const std::string& key, CheckFunc check_func_ptr, bool rewritable, std::string* value_ptr_vec)
+      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec) {
   }
   ~StringValue() override = default;
 
-  std::string Value() const override { return MergeString(values_, delimiter_); };
+  std::string Value() const override { return *values_; };
 
  private:
   Status SetValue(const std::string& value) override;
 
-  std::vector<std::string*> values_;
+  std::string* values_;
+};
+
+class StringValueArray : public BaseValue {
+ public:
+  StringValueArray(const std::string& key, CheckFunc check_func_ptr, bool rewritable,
+                   std::vector<std::string>& value_ptr_vec, char delimiter = ' ')
+      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec), delimiter_(delimiter) {
+  }
+  ~StringValueArray() override = default;
+
+  std::string Value() const override { return pstd::StringConcat(values_, delimiter_); };
+
+ private:
+  Status SetValue(const std::string& value) override;
+
+  std::vector<std::string> values_;
   char delimiter_ = 0;
 };
 
@@ -91,18 +105,34 @@ class NumberValue : public BaseValue {
 
   std::string Value() const override { return std::to_string(*value_); }
 
- private:
-  Status SetValue(const std::string& value) override;
-
+ protected:
   T* value_ = nullptr;
+
+ private:
   T value_min_;
   T value_max_;
+
+ protected:
+  Status SetValue(const std::string& value) override;
+};
+
+class MemorySize : public NumberValue<size_t> {
+ public:
+  MemorySize(const std::string& key, CheckFunc check_func_ptr, bool rewritable, size_t* value_ptr)
+      : NumberValue<size_t>(key, std::move(check_func_ptr), rewritable, value_ptr) {
+    assert(value_ptr != nullptr);
+  };
+
+  std::string Value() const override { return std::to_string(*value_); };
+
+ protected:
+  Status SetValue(const std::string& value) override;
 };
 
 class BoolValue : public BaseValue {
  public:
   BoolValue(const std::string& key, CheckFunc check_func_ptr, bool rewritable, bool* value_ptr)
-      : BaseValue(key, check_func_ptr, rewritable), value_(value_ptr) {
+      : BaseValue(key, std::move(check_func_ptr), rewritable), value_(value_ptr) {
     assert(value_ != nullptr);
   };
 
@@ -356,7 +386,7 @@ class PConfig {
   // Some functions and variables set up for internal work.
 
   /*------------------------
-   * AddString (const std::string& key, bool rewritable, * std::vector<std::string*> values_ptr_vector)
+   * AddString (const std::string& key, bool rewritable, std::string* values_ptr_vector)
    * Introduce a new string key-value pair into the
    * configuration data layer.
    * A key may correspond to multiple values, so we use std::vector
@@ -364,8 +394,22 @@ class PConfig {
    * rewritable represents whether to overwrite existing settings
    * when a key-value pair is duplicated.
    */
-  void AddString(const std::string& key, bool rewritable, std::vector<std::string*> values_ptr_vector) {
-    config_map_.emplace(key, std::make_unique<StringValue>(key, nullptr, rewritable, values_ptr_vector));
+  void AddString(const std::string& key, bool rewritable, std::string* values_ptr) {
+    config_map_.emplace(key, std::make_unique<StringValue>(key, nullptr, rewritable, values_ptr));
+  }
+
+  /*
+   * AddStringArray (const std::string& key, bool rewritable, std::vector<std::string*> values_ptr_vector)
+   * Introduce a new string key-value pair into the
+   * configuration data layer.
+   * A key may correspond to multiple values, so we use std::vector
+   * to store the data.
+   * rewritable represents whether to overwrite existing settings
+   * when a key-value pair is duplicated.
+   * support read string array from config file,default delimiter is ' '
+   */
+  void AddStringArray(const std::string& key, bool rewritable, std::vector<std::string> values_ptr_vector) {
+    config_map_.emplace(key, std::make_unique<StringValueArray>(key, nullptr, rewritable, values_ptr_vector));
   }
 
   /*------------------------
@@ -378,7 +422,7 @@ class PConfig {
    * and the return value should refer to rocksdb::Status.
    */
   void AddStringWithFunc(const std::string& key, const CheckFunc& checkfunc, bool rewritable,
-                         std::vector<std::string*> values_ptr_vector) {
+                         std::string* values_ptr_vector) {
     config_map_.emplace(key, std::make_unique<StringValue>(key, checkfunc, rewritable, values_ptr_vector));
   }
 
@@ -423,6 +467,22 @@ class PConfig {
   template <typename T>
   void AddNumberWithLimit(const std::string& key, bool rewritable, T* value_ptr, T min, T max) {
     config_map_.emplace(key, std::make_unique<NumberValue<T>>(key, nullptr, rewritable, value_ptr, min, max));
+  }
+
+  /*
+   * AddMemorySize (const std::string& key, bool rewritable, size_t* value_ptr)
+   * Introduce a new string key-value pair into the
+   * configuration data layer, with a check function.
+   * key is a string and value_ptr is a set of numbers.
+   * rewritable represents whether to overwrite existing settings
+   * when a key-value pair is duplicated.
+   * This function is used to set the memory size.
+   * The memory size is a special case of the number, so we use
+   * the MemorySize class to handle it.
+   * support the unit of memory size: B, KB, MB, GB,default is B.
+   */
+  void AddMemorySize(const std::string& key, bool rewritable, size_t* value_ptr) {
+    config_map_.emplace(key, std::make_unique<MemorySize>(key, nullptr, rewritable, value_ptr));
   }
 
  private:


### PR DESCRIPTION
支持读取配置时区分简单字符串和字符串数组, 现在读取配置中带 ' ' 的配置会自动分割,导致一些配置无法正确读取,为后面支持ACL做好准备

支持读取带单位内存配置, 比如 10M 会自动转成 10,485,760 byte


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "RAFT" configuration section with options for future use.
	- Added support for memory size configurations with suffix handling.
	- New `StringValueArray` class for managing arrays of strings.

- **Bug Fixes**
	- Improved handling of configuration values to prevent unnecessary resizing.

- **Documentation**
	- Updated configuration management structure to enhance clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->