### PR TITLE
refactor: resp AppendArrayLen optimize

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -134,13 +134,10 @@ class PClient : public std::enable_shared_from_this<PClient> {
   // reply
   void SetRes(CmdRes _ret, const std::string& content = "") { resp_encode_->SetRes(_ret, content); };
 
+  // If T is of type string, then the contents of string must be numbers
   template <typename T>
   requires(std::integral<T> || std::same_as<T, std::string>) void AppendArrayLen(T value) {
-    if constexpr (std::integral<T>) {
-      AppendStringRaw(fmt::format("*{}\r\n", pstd::Int2string(value)));
-    } else {
-      AppendStringRaw(fmt::format("*{}\r\n", value));
-    }
+    AppendStringRaw(fmt::format("*{}\r\n", value));
   }
 
   void AppendInteger(int64_t value) { resp_encode_->AppendInteger(value); }


### PR DESCRIPTION
`fmt::format` 函数支持string和数字,去掉之前的额外判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated comments for the `AppendArrayLen` method to clarify expected behavior for string types.
  
- **Refactor**
	- Simplified the `AppendArrayLen` method by removing conditional logic for type handling, enhancing code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->