### PR TITLE
[WIP]fix: Make-p_config-a-singleton

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -42,7 +42,7 @@ void BaseCmd::Execute(PClient* client) {
   DEBUG("execute command: {}", client->CmdName());
 
   // read consistency (lease read) / write redirection
-  if (g_config.use_raft && (HasFlag(kCmdFlagsReadonly) || HasFlag(kCmdFlagsWrite))) {
+  if (kiwi::PConfig::GetInstance().use_raft && (HasFlag(kCmdFlagsReadonly) || HasFlag(kCmdFlagsWrite))) {
     if (!PRAFT.IsInitialized()) {
       return client->SetRes(CmdRes::kErrOther, "PRAFT is not initialized");
     }

--- a/src/client.cc
+++ b/src/client.cc
@@ -239,7 +239,7 @@ void PClient::OnConnect() {
     SetName("MasterConnection");
     SetFlag(kClientFlagMaster);
 
-    if (g_config.master_auth.empty()) {
+    if (kiwi::PConfig::GetInstance().master_auth.empty()) {
       SetAuth();
     }
 
@@ -247,7 +247,7 @@ void PClient::OnConnect() {
       PRAFT.SendNodeRequest(this);
     }
   } else {
-    if (g_config.password.empty()) {
+    if (kiwi::PConfig::GetInstance().password.empty()) {
       SetAuth();
     }
   }

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -55,7 +55,7 @@ bool CmdConfigGet::DoInitial(PClient* client) { return true; }
 void CmdConfigGet::DoCmd(PClient* client) {
   std::vector<std::string> results;
   for (int i = 0; i < client->argv_.size() - 2; i++) {
-    g_config.Get(client->argv_[i + 2], &results);
+    kiwi::PConfig::GetInstance().Get(client->argv_[i + 2], &results);
   }
   client->AppendStringVector(results);
 }
@@ -66,7 +66,7 @@ CmdConfigSet::CmdConfigSet(const std::string& name, int16_t arity)
 bool CmdConfigSet::DoInitial(PClient* client) { return true; }
 
 void CmdConfigSet::DoCmd(PClient* client) {
-  auto s = g_config.Set(client->argv_[2], client->argv_[3]);
+  auto s = kiwi::PConfig::GetInstance().Set(client->argv_[2], client->argv_[3]);
   if (!s.ok()) {
     client->SetRes(CmdRes::kInvalidParameter);
   } else {
@@ -85,7 +85,7 @@ void FlushdbCmd::DoCmd(PClient* client) {
   PSTORE.GetBackend(currentDBIndex).get()->Lock();
   DEFER { PSTORE.GetBackend(currentDBIndex).get()->UnLock(); };
 
-  std::string db_path = g_config.db_path + std::to_string(currentDBIndex);
+  std::string db_path = kiwi::PConfig::GetInstance().db_path + std::to_string(currentDBIndex);
   std::string path_temp = db_path;
   path_temp.append("_deleting/");
   pstd::RenameFile(db_path, path_temp);
@@ -106,9 +106,9 @@ FlushallCmd::FlushallCmd(const std::string& name, int16_t arity)
 bool FlushallCmd::DoInitial(PClient* client) { return true; }
 
 void FlushallCmd::DoCmd(PClient* client) {
-  for (size_t i = 0; i < g_config.databases; ++i) {
+  for (size_t i = 0; i < kiwi::PConfig::GetInstance().databases; ++i) {
     PSTORE.GetBackend(i).get()->Lock();
-    std::string db_path = g_config.db_path + std::to_string(i);
+    std::string db_path = kiwi::PConfig::GetInstance().db_path + std::to_string(i);
     std::string path_temp = db_path;
     path_temp.append("_deleting/");
     pstd::RenameFile(db_path, path_temp);
@@ -128,7 +128,7 @@ bool SelectCmd::DoInitial(PClient* client) { return true; }
 
 void SelectCmd::DoCmd(PClient* client) {
   int index = atoi(client->argv_[1].c_str());
-  if (index < 0 || index >= g_config.databases) {
+  if (index < 0 || index >= kiwi::PConfig::GetInstance().databases) {
     client->SetRes(CmdRes::kInvalidIndex, kCmdNameSelect + " DB index is out of range");
     return;
   }
@@ -142,7 +142,7 @@ ShutdownCmd::ShutdownCmd(const std::string& name, int16_t arity)
 bool ShutdownCmd::DoInitial(PClient* client) {
   // For now, only shutdown need check local
   if (client->PeerIP().find("127.0.0.1") == std::string::npos &&
-      client->PeerIP().find(g_config.ip) == std::string::npos) {
+      client->PeerIP().find(kiwi::PConfig::GetInstance().ip) == std::string::npos) {
     client->SetRes(CmdRes::kErrOther, kCmdNameShutdown + " should be localhost");
     return false;
   }
@@ -207,7 +207,7 @@ void HelloCmd::DoCmd(PClient* client) {
       if (client->GetAuth()) {
         continue;
       }
-      if (client->argv_[next_arg + 1] != g_config.password) {
+      if (client->argv_[next_arg + 1] != kiwi::PConfig::GetInstance().password) {
         client->SetRes(CmdRes::kErrOther, "invalid password");
         return;
       } else {
@@ -243,7 +243,7 @@ void HelloCmd::Hello(PClient* client) {
   client->AppendInteger(static_cast<int64_t>(client->GetUniqueID()));
   client->AppendString("mode");
 
-  if (!g_config.use_raft) {
+  if (!kiwi::PConfig::GetInstance().use_raft) {
     client->AppendString("standalone");
   } else {
     client->AppendString("cluster");
@@ -427,8 +427,8 @@ void InfoCmd::InfoServer(std::string& info) {
   tmp_stream << "os:" << host_info.sysname << " " << host_info.release << " " << host_info.machine << "\r\n";
   tmp_stream << "arch_bits:" << (reinterpret_cast<char*>(&host_info.machine) + strlen(host_info.machine) - 2) << "\r\n";
   tmp_stream << "process_id:" << getpid() << "\r\n";
-  tmp_stream << "run_id:" << static_cast<std::string>(g_config.run_id) << "\r\n";
-  tmp_stream << "tcp_port:" << g_config.port << "\r\n";
+  tmp_stream << "run_id:" << static_cast<std::string>(kiwi::PConfig::GetInstance().run_id) << "\r\n";
+  tmp_stream << "tcp_port:" << kiwi::PConfig::GetInstance().port << "\r\n";
   tmp_stream << "uptime_in_seconds:" << (current_time_s - g_kiwi->Start_time_s()) << "\r\n";
   tmp_stream << "uptime_in_days:" << (current_time_s / (24 * 3600) - g_kiwi->Start_time_s() / (24 * 3600) + 1)
              << "\r\n";
@@ -471,8 +471,8 @@ void InfoCmd::InfoCPU(std::string& info) {
 }
 
 void InfoCmd::InfoData(std::string& message) {
-  message += DATABASES_NUM + std::string(":") + std::to_string(kiwi::g_config.databases) + "\r\n";
-  message += ROCKSDB_NUM + std::string(":") + std::to_string(kiwi::g_config.db_instance_num) + "\r\n";
+  message += DATABASES_NUM + std::string(":") + std::to_string(kiwi::PConfig::GetInstance().databases) + "\r\n";
+  message += ROCKSDB_NUM + std::string(":") + std::to_string(kiwi::PConfig::GetInstance().db_instance_num) + "\r\n";
   message += ROCKSDB_VERSION + std::string(":") + ROCKSDB_NAMESPACE::GetRocksVersionAsString() + "\r\n";
 }
 

--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -172,7 +172,7 @@ void HGetAllCmd::DoCmd(PClient* client) {
   int64_t total_fv = 0;
   int64_t cursor = 0;
   int64_t next_cursor = 0;
-  size_t raw_limit = g_config.max_client_response_size;
+  size_t raw_limit = kiwi::PConfig::GetInstance().max_client_response_size;
   std::string raw;
   std::vector<storage::FieldValue> fvs;
   storage::Status s;

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -680,7 +680,7 @@ void SetRangeCmd::DoCmd(PClient* client) {
     return;
   }
   // Ref: https://redis.io/docs/latest/commands/setrange/
-  if (g_config.redis_compatible_mode && std::atoi(client->argv_[2].c_str()) > 536870911) {
+  if (kiwi::PConfig::GetInstance().redis_compatible_mode && std::atoi(client->argv_[2].c_str()) > 536870911) {
     client->SetRes(CmdRes::kErrOther,
                    "When Redis compatibility mode is enabled, the offset parameter must not exceed 536870911");
     return;

--- a/src/cmd_raft.cc
+++ b/src/cmd_raft.cc
@@ -103,7 +103,7 @@ void RaftNodeCmd::DoCmdRemove(PClient* client) {
 
     // Connect target
     std::string peer_ip = butil::ip2str(leader_peer_id.addr.ip).c_str();
-    auto port = leader_peer_id.addr.port - kiwi::g_config.raft_port_offset;
+    auto port = leader_peer_id.addr.port - kiwi::PConfig::GetInstance().raft_port_offset;
     auto peer_id = client->argv_[2];
     auto ret =
         PRAFT.GetClusterCmdCtx().Set(ClusterCmdType::kRemove, client, std::move(peer_ip), port, std::move(peer_id));

--- a/src/config.cc
+++ b/src/config.cc
@@ -23,7 +23,7 @@ constexpr int DBNUMBER_MAX = 16;
 constexpr int THREAD_MAX = 129;
 constexpr int ROCKSDB_INSTANCE_NUMBER_MAX = 10;
 
-PConfig g_config;
+PConfig &g_config=kiwi::PConfig::GetInstance();
 
 // preprocess func
 static void EraseQuotes(std::string& str) {
@@ -207,8 +207,10 @@ bool PConfig::LoadFromFile(const std::string& file_name) {
 }
 
 void PConfig::Get(const std::string& key, std::vector<std::string>* values) const {
+  std::lock_guard<std::mutex> lock(mutex_);
   values->clear();
   for (const auto& [k, v] : config_map_) {
+    
     if (key == "*" || pstd::StringMatch(key.c_str(), k.c_str(), 1)) {
       values->emplace_back(k);
       values->emplace_back(v->Value());
@@ -217,6 +219,7 @@ void PConfig::Get(const std::string& key, std::vector<std::string>* values) cons
 }
 
 Status PConfig::Set(std::string key, const std::string& value, bool init_stage) {
+  std::lock_guard<std::mutex> lock(mutex_);
   std::transform(key.begin(), key.end(), key.begin(), ::tolower);
   auto iter = config_map_.find(key);
   if (iter == config_map_.end()) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -23,7 +23,7 @@ constexpr int DBNUMBER_MAX = 16;
 constexpr int THREAD_MAX = 129;
 constexpr int ROCKSDB_INSTANCE_NUMBER_MAX = 10;
 
-PConfig &g_config=kiwi::PConfig::GetInstance();
+PConfig& g_config = kiwi::PConfig::GetInstance();
 
 // preprocess func
 static void EraseQuotes(std::string& str) {
@@ -210,7 +210,6 @@ void PConfig::Get(const std::string& key, std::vector<std::string>* values) cons
   std::lock_guard<std::mutex> lock(mutex_);
   values->clear();
   for (const auto& [k, v] : config_map_) {
-    
     if (key == "*" || pstd::StringMatch(key.c_str(), k.c_str(), 1)) {
       values->emplace_back(k);
       values->emplace_back(v->Value());

--- a/src/config.h
+++ b/src/config.h
@@ -31,7 +31,7 @@ using Status = rocksdb::Status;
 using CheckFunc = std::function<Status(const std::string&)>;
 class PConfig;
 
-extern PConfig g_config;
+
 
 class BaseValue {
  public:
@@ -156,8 +156,12 @@ class PConfig {
    * PConfig()
    * Initialize kiwi's config & RocksDB's config.
    */
-  PConfig();
-
+  static PConfig& GetInstance() {
+    static PConfig instance;
+    return instance;
+  }
+  PConfig(const PConfig&) = delete;
+  PConfig& operator=(const PConfig&) = delete;
   /*------------------------
    * ~PConfig()
    * Destroy a kiwi's config instance.
@@ -393,6 +397,7 @@ class PConfig {
    * when a key-value pair is duplicated.
    */
   void AddString(const std::string& key, bool rewritable, std::string* values_ptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<StringValue>(key, nullptr, rewritable, values_ptr));
   }
 
@@ -407,6 +412,8 @@ class PConfig {
    * support read string array from config file,default delimiter is ' '
    */
   void AddStringArray(const std::string& key, bool rewritable, std::vector<std::string> values_ptr_vector) {
+    
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<StringValueArray>(key, nullptr, rewritable, values_ptr_vector));
   }
 
@@ -421,6 +428,7 @@ class PConfig {
    */
   void AddStringWithFunc(const std::string& key, const CheckFunc& checkfunc, bool rewritable,
                          std::string* values_ptr_vector) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<StringValue>(key, checkfunc, rewritable, values_ptr_vector));
   }
 
@@ -435,6 +443,7 @@ class PConfig {
    * when a key-value pair is duplicated.
    */
   void AddBool(const std::string& key, const CheckFunc& checkfunc, bool rewritable, bool* value_ptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<BoolValue>(key, checkfunc, rewritable, value_ptr));
   }
 
@@ -448,6 +457,7 @@ class PConfig {
    */
   template <typename T>
   void AddNumber(const std::string& key, bool rewritable, T* value_ptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<NumberValue<T>>(key, nullptr, rewritable, value_ptr));
   }
 
@@ -464,6 +474,7 @@ class PConfig {
    */
   template <typename T>
   void AddNumberWithLimit(const std::string& key, bool rewritable, T* value_ptr, T min, T max) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<NumberValue<T>>(key, nullptr, rewritable, value_ptr, min, max));
   }
 
@@ -480,6 +491,7 @@ class PConfig {
    * support the unit of memory size: B, KB, MB, GB,default is B.
    */
   void AddMemorySize(const std::string& key, bool rewritable, size_t* value_ptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<MemorySize>(key, nullptr, rewritable, value_ptr));
   }
 
@@ -492,5 +504,7 @@ class PConfig {
 
   // The file name of the config
   std::string config_file_name_;
+  PConfig();
+  mutable std::mutex mutex_;
 };
 }  // namespace kiwi

--- a/src/config.h
+++ b/src/config.h
@@ -31,8 +31,6 @@ using Status = rocksdb::Status;
 using CheckFunc = std::function<Status(const std::string&)>;
 class PConfig;
 
-
-
 class BaseValue {
  public:
   BaseValue(std::string key, CheckFunc check_func_ptr, bool rewritable = false)
@@ -412,7 +410,6 @@ class PConfig {
    * support read string array from config file,default delimiter is ' '
    */
   void AddStringArray(const std::string& key, bool rewritable, std::vector<std::string> values_ptr_vector) {
-    
     std::lock_guard<std::mutex> lock(mutex_);
     config_map_.emplace(key, std::make_unique<StringValueArray>(key, nullptr, rewritable, values_ptr_vector));
   }

--- a/src/db.cc
+++ b/src/db.cc
@@ -15,8 +15,6 @@
 #include "praft/praft.h"
 #include "pstd/log.h"
 
-
-
 namespace kiwi {
 
 DB::DB(int db_index, const std::string& db_path)
@@ -33,7 +31,8 @@ rocksdb::Status DB::Open() {
   storage_options.options.periodic_compaction_seconds = kiwi::PConfig::GetInstance().rocksdb_periodic_second;
 
   storage_options.small_compaction_threshold = kiwi::PConfig::GetInstance().small_compaction_threshold;
-  storage_options.small_compaction_duration_threshold = kiwi::PConfig::GetInstance().small_compaction_duration_threshold;
+  storage_options.small_compaction_duration_threshold =
+      kiwi::PConfig::GetInstance().small_compaction_duration_threshold;
 
   if (kiwi::PConfig::GetInstance().use_raft) {
     storage_options.append_log_function = [&r = PRAFT](const Binlog& log, std::promise<rocksdb::Status>&& promise) {

--- a/src/db.cc
+++ b/src/db.cc
@@ -15,7 +15,7 @@
 #include "praft/praft.h"
 #include "pstd/log.h"
 
-extern kiwi::PConfig g_config;
+
 
 namespace kiwi {
 
@@ -26,16 +26,16 @@ DB::~DB() { INFO("DB{} is closing...", db_index_); }
 
 rocksdb::Status DB::Open() {
   storage::StorageOptions storage_options;
-  storage_options.options = g_config.GetRocksDBOptions();
-  storage_options.table_options = g_config.GetRocksDBBlockBasedTableOptions();
+  storage_options.options = kiwi::PConfig::GetInstance().GetRocksDBOptions();
+  storage_options.table_options = kiwi::PConfig::GetInstance().GetRocksDBBlockBasedTableOptions();
 
-  storage_options.options.ttl = g_config.rocksdb_ttl_second;
-  storage_options.options.periodic_compaction_seconds = g_config.rocksdb_periodic_second;
+  storage_options.options.ttl = kiwi::PConfig::GetInstance().rocksdb_ttl_second;
+  storage_options.options.periodic_compaction_seconds = kiwi::PConfig::GetInstance().rocksdb_periodic_second;
 
-  storage_options.small_compaction_threshold = g_config.small_compaction_threshold;
-  storage_options.small_compaction_duration_threshold = g_config.small_compaction_duration_threshold;
+  storage_options.small_compaction_threshold = kiwi::PConfig::GetInstance().small_compaction_threshold;
+  storage_options.small_compaction_duration_threshold = kiwi::PConfig::GetInstance().small_compaction_duration_threshold;
 
-  if (g_config.use_raft) {
+  if (kiwi::PConfig::GetInstance().use_raft) {
     storage_options.append_log_function = [&r = PRAFT](const Binlog& log, std::promise<rocksdb::Status>&& promise) {
       r.AppendLog(log, std::move(promise));
     };
@@ -45,7 +45,7 @@ rocksdb::Status DB::Open() {
     };
   }
 
-  storage_options.db_instance_num = g_config.db_instance_num;
+  storage_options.db_instance_num = kiwi::PConfig::GetInstance().db_instance_num;
   storage_options.db_id = db_index_;
 
   std::unique_ptr<storage::Storage> old_storage = std::move(storage_);
@@ -110,14 +110,14 @@ void DB::LoadDBFromCheckpoint(const std::string& checkpoint_path, bool sync [[ma
   }
 
   storage::StorageOptions storage_options;
-  storage_options.options = g_config.GetRocksDBOptions();
-  storage_options.db_instance_num = g_config.db_instance_num;
+  storage_options.options = kiwi::PConfig::GetInstance().GetRocksDBOptions();
+  storage_options.db_instance_num = kiwi::PConfig::GetInstance().db_instance_num;
   storage_options.db_id = db_index_;
 
   // options for CF
-  storage_options.options.ttl = g_config.rocksdb_ttl_second;
-  storage_options.options.periodic_compaction_seconds = g_config.rocksdb_periodic_second;
-  if (g_config.use_raft) {
+  storage_options.options.ttl = kiwi::PConfig::GetInstance().rocksdb_ttl_second;
+  storage_options.options.periodic_compaction_seconds = kiwi::PConfig::GetInstance().rocksdb_periodic_second;
+  if (kiwi::PConfig::GetInstance().use_raft) {
     storage_options.append_log_function = [&r = PRAFT](const Binlog& log, std::promise<rocksdb::Status>&& promise) {
       r.AppendLog(log, std::move(promise));
     };
@@ -131,7 +131,7 @@ void DB::LoadDBFromCheckpoint(const std::string& checkpoint_path, bool sync [[ma
   }
 
   // in single-mode, kiwi will enable wal
-  if (!g_config.use_raft) {
+  if (!kiwi::PConfig::GetInstance().use_raft) {
     storage_->DisableWal(false);
   }
 

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -163,46 +163,46 @@ void KiwiDB::OnNewConnection(uint64_t connId, std::shared_ptr<kiwi::PClient>& cl
 bool KiwiDB::Init() {
   char runid[kRunidSize + 1] = "";
   getRandomHexChars(runid, kRunidSize);
-  g_config.Set("runid", {runid, kRunidSize}, true);
+  kiwi::PConfig::GetInstance().Set("runid", {runid, kRunidSize}, true);
 
   if (port_ != 0) {
-    g_config.Set("port", std::to_string(port_), true);
+    kiwi::PConfig::GetInstance().Set("port", std::to_string(port_), true);
   }
 
   if (!options_.GetLogLevel().empty()) {
-    g_config.Set("log-level", options_.GetLogLevel(), true);
+    kiwi::PConfig::GetInstance().Set("log-level", options_.GetLogLevel(), true);
   }
 
   if (options_.GetRedisCompatibleMode()) {
-    g_config.Set("redis_compatible_mode", std::to_string(options_.GetRedisCompatibleMode()), true);
+    kiwi::PConfig::GetInstance().Set("redis_compatible_mode", std::to_string(options_.GetRedisCompatibleMode()), true);
   }
 
-  auto num = g_config.worker_threads_num + g_config.slave_threads_num;
+  auto num = kiwi::PConfig::GetInstance().worker_threads_num + kiwi::PConfig::GetInstance().slave_threads_num;
   options_.SetThreadNum(num);
 
   // now we only use fast cmd thread pool
-  auto status = cmd_threads_.Init(g_config.fast_cmd_threads_num, 1, "kiwi-cmd");
+  auto status = cmd_threads_.Init(kiwi::PConfig::GetInstance().fast_cmd_threads_num, 1, "kiwi-cmd");
   if (!status.ok()) {
     ERROR("init cmd thread pool failed: {}", status.ToString());
     return false;
   }
 
-  PSTORE.Init(g_config.databases);
+  PSTORE.Init(kiwi::PConfig::GetInstance().databases);
 
-  PSlowLog::Instance().SetThreshold(g_config.slow_log_time);
-  PSlowLog::Instance().SetLogLimit(static_cast<std::size_t>(g_config.slow_log_max_len));
+  PSlowLog::Instance().SetThreshold(kiwi::PConfig::GetInstance().slow_log_time);
+  PSlowLog::Instance().SetLogLimit(static_cast<std::size_t>(kiwi::PConfig::GetInstance().slow_log_max_len));
 
   // master ip
-  if (!g_config.master_ip.empty()) {
-    PREPL.SetMasterAddr(g_config.master_ip.c_str(), g_config.master_port);
+  if (!kiwi::PConfig::GetInstance().master_ip.empty()) {
+    PREPL.SetMasterAddr(kiwi::PConfig::GetInstance().master_ip.c_str(), kiwi::PConfig::GetInstance().master_port);
   }
 
   options_.SetRwSeparation(true);
 
   event_server_ = std::make_unique<net::EventServer<std::shared_ptr<PClient>>>(options_);
 
-  net::SocketAddr addr(g_config.ip, g_config.port);
-  INFO("Add listen addr:{}, port:{}", g_config.ip, g_config.port);
+  net::SocketAddr addr(kiwi::PConfig::GetInstance().ip, kiwi::PConfig::GetInstance().port);
+  INFO("Add listen addr:{}, port:{}", kiwi::PConfig::GetInstance().ip, kiwi::PConfig::GetInstance().port);
   event_server_->AddListenAddr(addr);
 
   event_server_->SetOnInit([](std::shared_ptr<PClient>* client) { *client = std::make_shared<PClient>(); });
@@ -273,7 +273,7 @@ static void InitLogs() {
 
 static int InitLimit() {
   rlimit limit;
-  rlim_t maxfiles = g_config.max_clients;
+  rlim_t maxfiles = kiwi::PConfig::GetInstance().max_clients;
   if (getrlimit(RLIMIT_NOFILE, &limit) == -1) {
     WARN("getrlimit error: {}", strerror(errno));
   } else if (limit.rlim_cur < maxfiles) {
@@ -324,13 +324,13 @@ int main(int argc, char* argv[]) {
   }
 
   if (!g_kiwi->GetConfigName().empty()) {
-    if (!g_config.LoadFromFile(g_kiwi->GetConfigName())) {
+    if (!kiwi::PConfig::GetInstance().LoadFromFile(g_kiwi->GetConfigName())) {
       std::cerr << "Load config file [" << g_kiwi->GetConfigName() << "] failed!\n";
       return -1;
     }
   }
 
-  if (g_config.daemonize) {
+  if (kiwi::PConfig::GetInstance().daemonize) {
     daemonize();
   }
 
@@ -339,7 +339,7 @@ int main(int argc, char* argv[]) {
   InitLogs();
   InitLimit();
 
-  if (g_config.daemonize) {
+  if (kiwi::PConfig::GetInstance().daemonize) {
     closeStd();
   }
 
@@ -347,7 +347,7 @@ int main(int argc, char* argv[]) {
     // output logo to console
     char logo[1024] = "";
     snprintf(logo, sizeof logo - 1, kiwiLogo, Kkiwi_VERSION, static_cast<int>(sizeof(void*)) * 8,
-             static_cast<int>(g_config.port));
+             static_cast<int>(kiwi::PConfig::GetInstance().port));
     std::cout << logo;
     g_kiwi->Run();
   }

--- a/src/praft/praft.cc
+++ b/src/praft/praft.cc
@@ -97,7 +97,7 @@ butil::Status PRaft::Init(std::string& group_id, bool initial_conf_is_null) {
   }
 
   server_ = std::make_unique<brpc::Server>();
-  auto port = g_config.port + kiwi::g_config.raft_port_offset;
+  auto port = kiwi::PConfig::GetInstance().port + kiwi::PConfig::GetInstance().raft_port_offset;
   // Add your service into RPC server
   DummyServiceImpl service(&PRAFT);
   if (server_->AddService(&service, brpc::SERVER_DOESNT_OWN_SERVICE) != 0) {
@@ -126,10 +126,10 @@ butil::Status PRaft::Init(std::string& group_id, bool initial_conf_is_null) {
   assert(group_id.size() == RAFT_GROUPID_LEN);
   this->group_id_ = group_id;
 
-  // FIXME: g_config.ip is default to 127.0.0.0, which may not work in cluster.
-  raw_addr_ = g_config.ip + ":" + std::to_string(port);
+  // FIXME: kiwi::PConfig::GetInstance().ip is default to 127.0.0.0, which may not work in cluster.
+  raw_addr_ = kiwi::PConfig::GetInstance().ip + ":" + std::to_string(port);
   butil::ip_t ip;
-  auto ret = butil::str2ip(g_config.ip.c_str(), &ip);
+  auto ret = butil::str2ip(kiwi::PConfig::GetInstance().ip.c_str(), &ip);
   if (ret != 0) {
     server_.reset();
     return ERROR_LOG_AND_STATUS("Failed to convert str_ip to butil::ip_t");
@@ -157,7 +157,7 @@ butil::Status PRaft::Init(std::string& group_id, bool initial_conf_is_null) {
   node_options_.fsm = this;
   node_options_.node_owns_fsm = false;
   node_options_.snapshot_interval_s = 0;
-  std::string prefix = "local://" + g_config.db_path + std::to_string(db_id_) + "/_praft";
+  std::string prefix = "local://" + kiwi::PConfig::GetInstance().db_path + std::to_string(db_id_) + "/_praft";
   node_options_.log_uri = prefix + "/log";
   node_options_.raft_meta_uri = prefix + "/raft_meta";
   node_options_.snapshot_uri = prefix + "/snapshot";
@@ -221,7 +221,7 @@ std::string PRaft::GetLeaderAddress() const {
     return std::string();
   }
 
-  id.addr.port -= g_config.raft_port_offset;
+  id.addr.port -= kiwi::PConfig::GetInstance().raft_port_offset;
   auto addr = butil::endpoint2str(id.addr);
   return addr.c_str();
 }
@@ -323,8 +323,8 @@ void PRaft::SendNodeAddRequest(PClient* client) {
 
   // Node id in braft are ip:port, the node id param in RAFT.NODE ADD cmd will be ignored.
   int unused_node_id = 0;
-  auto port = g_config.port + kiwi::g_config.raft_port_offset;
-  auto raw_addr = g_config.ip + ":" + std::to_string(port);
+  auto port = kiwi::PConfig::GetInstance().port + kiwi::PConfig::GetInstance().raft_port_offset;
+  auto raw_addr = kiwi::PConfig::GetInstance().ip + ":" + std::to_string(port);
 
   client->AppendArrayLen(int64_t(4));
   client->AppendString("RAFT.NODE");
@@ -394,8 +394,8 @@ void PRaft::CheckRocksDBConfiguration(PClient* client, PClient* join_client, con
     }
   }
 
-  int current_databases_num = kiwi::g_config.databases;
-  int current_rocksdb_num = kiwi::g_config.db_instance_num;
+  int current_databases_num = kiwi::PConfig::GetInstance().databases;
+  int current_rocksdb_num = kiwi::PConfig::GetInstance().db_instance_num;
   std::string current_rocksdb_version = ROCKSDB_NAMESPACE::GetRocksVersionAsString();
   if (current_databases_num != databases_num || current_rocksdb_num != rocksdb_num ||
       current_rocksdb_version != rockdb_version) {
@@ -714,7 +714,7 @@ int PRaft::on_snapshot_load(braft::SnapshotReader* reader) {
 
   // 3. When a snapshot is installed on a node, you do not need to set a playback point.
   auto reader_path = reader->get_path();                  // xx/snapshot_0000001
-  auto path = g_config.db_path + std::to_string(db_id_);  // db/db_id
+  auto path = kiwi::PConfig::GetInstance().db_path + std::to_string(db_id_);  // db/db_id
   TasksVector tasks(1, {TaskType::kLoadDBFromCheckpoint, db_id_, {{TaskArg::kCheckpointPath, reader_path}}, true});
   PSTORE.HandleTaskSpecificDB(tasks);
   INFO("load snapshot success!");

--- a/src/praft/praft.cc
+++ b/src/praft/praft.cc
@@ -713,7 +713,7 @@ int PRaft::on_snapshot_load(braft::SnapshotReader* reader) {
   }
 
   // 3. When a snapshot is installed on a node, you do not need to set a playback point.
-  auto reader_path = reader->get_path();                  // xx/snapshot_0000001
+  auto reader_path = reader->get_path();                                      // xx/snapshot_0000001
   auto path = kiwi::PConfig::GetInstance().db_path + std::to_string(db_id_);  // db/db_id
   TasksVector tasks(1, {TaskType::kLoadDBFromCheckpoint, db_id_, {{TaskArg::kCheckpointPath, reader_path}}, true});
   PSTORE.HandleTaskSpecificDB(tasks);

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -177,7 +177,8 @@ void PReplication::Cron() {
   if (masterInfo_.addr.IsValid()) {
     switch (masterInfo_.state) {
       case kPReplStateNone: {
-        if (masterInfo_.addr.GetIP() == kiwi::PConfig::GetInstance().ip && masterInfo_.addr.GetPort() == kiwi::PConfig::GetInstance().port) {
+        if (masterInfo_.addr.GetIP() == kiwi::PConfig::GetInstance().ip &&
+            masterInfo_.addr.GetPort() == kiwi::PConfig::GetInstance().port) {
           ERROR("Fix config, master addr is self addr!");
           assert(!!!"wrong config for master addr");
         }
@@ -224,7 +225,8 @@ void PReplication::Cron() {
         } else if (master->GetAuth()) {
           // send replconf
           char req[128];
-          auto len = snprintf(req, sizeof req - 1, "replconf listening-port %hu\r\n", kiwi::PConfig::GetInstance().port);
+          auto len =
+              snprintf(req, sizeof req - 1, "replconf listening-port %hu\r\n", kiwi::PConfig::GetInstance().port);
           std::string info(req, len);
           master->SendPacket(std::move(info));
           masterInfo_.state = kPReplStateWaitReplconf;

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -98,7 +98,7 @@ void PReplication::TryBgsave() {
   //  if (ret == 0) {
   //    {
   //      PDBSaver qdb;
-  //      qdb.Save(g_config.rdbfullname.c_str());
+  //      qdb.Save(kiwi::PConfig::GetInstance().rdbfullname.c_str());
   //      DEBUG("PReplication save rdb done, exiting child");
   //    }
   //    _exit(0);
@@ -177,7 +177,7 @@ void PReplication::Cron() {
   if (masterInfo_.addr.IsValid()) {
     switch (masterInfo_.state) {
       case kPReplStateNone: {
-        if (masterInfo_.addr.GetIP() == g_config.ip && masterInfo_.addr.GetPort() == g_config.port) {
+        if (masterInfo_.addr.GetIP() == kiwi::PConfig::GetInstance().ip && masterInfo_.addr.GetPort() == kiwi::PConfig::GetInstance().port) {
           ERROR("Fix config, master addr is self addr!");
           assert(!!!"wrong config for master addr");
         }
@@ -224,12 +224,12 @@ void PReplication::Cron() {
         } else if (master->GetAuth()) {
           // send replconf
           char req[128];
-          auto len = snprintf(req, sizeof req - 1, "replconf listening-port %hu\r\n", g_config.port);
+          auto len = snprintf(req, sizeof req - 1, "replconf listening-port %hu\r\n", kiwi::PConfig::GetInstance().port);
           std::string info(req, len);
           master->SendPacket(std::move(info));
           masterInfo_.state = kPReplStateWaitReplconf;
 
-          INFO("Send replconf listening-port {}", g_config.port);
+          INFO("Send replconf listening-port {}", kiwi::PConfig::GetInstance().port);
         } else {
           WARN("Haven't auth to master yet, or check masterauth password");
         }

--- a/src/store.cc
+++ b/src/store.cc
@@ -31,7 +31,7 @@ void PStore::Init(int db_number) {
   db_number_ = db_number;
   backends_.reserve(db_number_);
   for (int i = 0; i < db_number_; i++) {
-    auto db = std::make_unique<DB>(i, g_config.db_path);
+    auto db = std::make_unique<DB>(i, kiwi::PConfig::GetInstance().db_path);
     db->Open();
     backends_.push_back(std::move(db));
     INFO("Open DB_{} success!", i);


### PR DESCRIPTION
将PConfig类变成单例模式（懒汉式单例——局部静态变量），解决类里面参数值与调用不同步的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Configuration Management**
	- Implemented a singleton pattern for configuration access.
	- Enhanced thread safety for configuration methods with mutex locks.
	- Centralized configuration retrieval across multiple components.

- **Performance and Stability**
	- Improved encapsulation of configuration settings by removing global variables.
	- Standardized configuration access methods throughout the system.

- **Technical Improvements**
	- Updated configuration retrieval across various system components, ensuring consistent management.
	- Refactored methods to utilize the new configuration access pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->