### PR TITLE
feat:variable-length arguments in configuration(closes #146)

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -69,24 +69,21 @@ Status StringValue::SetValue(const std::string& value) {
   *values_ = value;
   return Status::OK();
 }
-
 Status StringValueArray::SetValue(const std::string& value) {
   auto values = SplitString(value, delimiter_);
   if (!values_->empty()) {  // if the value_ is not empty, check the number of parameters
-    if (values.size() != values_->size()) {
+    if (values.size() != values_->size() && !mul_conf_argu_) {
       return Status::InvalidArgument("The number of parameters does not match.");
     }
   } else {  // if the value_ is empty, resize the value_ to the size of the values
     values_->resize(values.size());
   }
-
   values_->clear();
   for (const auto& value : values) {
     values_->emplace_back(value);
   }
   return Status::OK();
 }
-
 Status BoolValue::SetValue(const std::string& value) {
   if (kstd::StringEqualCaseInsensitive(value, "yes")) {
     *value_ = true;
@@ -133,7 +130,7 @@ Status MemorySize::SetValue(const std::string& value) {
 Config::Config() {
   AddBool("redis-compatible-mode", &CheckYesNo, true, &redis_compatible_mode);
   AddBool("daemonize", &CheckYesNo, false, &daemonize);
-  AddStringArray("ips", false, &ips);
+  AddStringArray("ips", false, &ips, true);
   AddString("raft-ip", false, &raft_ip);
   AddNumberWithLimit<uint16_t>("port", false, &port, PORT_LIMIT_MIN, PORT_LIMIT_MAX);
   AddNumber("raft-port-offset", true, &raft_port_offset);

--- a/src/config.h
+++ b/src/config.h
@@ -90,7 +90,7 @@ class StringValueArray : public BaseValue {
 
   std::vector<std::string>* values_;
   char delimiter_ = 0;
-  bool mul_conf_argu_;
+  bool mul_conf_argu_ = false;
 };
 
 template <typename T>

--- a/src/config.h
+++ b/src/config.h
@@ -14,12 +14,12 @@
 #include <cstddef>
 #include <cstring>
 #include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
 #include "common.h"
 #include "config_parser.h"
 #include "rocksdb/options.h"
@@ -78,9 +78,11 @@ class StringValue : public BaseValue {
 class StringValueArray : public BaseValue {
  public:
   StringValueArray(const std::string& key, CheckFunc check_func_ptr, bool rewritable,
-                   std::vector<std::string>* value_ptr_vec, char delimiter = ' ')
-      : BaseValue(key, std::move(check_func_ptr), rewritable), values_(value_ptr_vec), delimiter_(delimiter) {}
-  ~StringValueArray() override = default;
+                   std::vector<std::string>* value_ptr_vec, char delimiter = ' ', bool mul_conf_argu = false)
+      : BaseValue(key, std::move(check_func_ptr), rewritable),
+        values_(value_ptr_vec),
+        delimiter_(delimiter),
+        mul_conf_argu_(mul_conf_argu) {}
 
   std::string Value() const override { return kstd::StringConcat(*values_, delimiter_); };
 
@@ -89,6 +91,7 @@ class StringValueArray : public BaseValue {
 
   std::vector<std::string>* values_;
   char delimiter_ = 0;
+  bool mul_conf_argu_;
 };
 
 template <typename T>
@@ -420,8 +423,10 @@ class Config {
    * when a key-value pair is duplicated.
    * support read string array from config file,default delimiter is ' '
    */
-  void AddStringArray(const std::string& key, bool rewritable, std::vector<std::string>* values_ptr_vector) {
-    config_map_.emplace(key, std::make_unique<StringValueArray>(key, nullptr, rewritable, values_ptr_vector));
+  void AddStringArray(const std::string& key, bool rewritable, std::vector<std::string>* values_ptr_vector,
+                      bool mul_conf_argu) {
+    config_map_.emplace(
+        key, std::make_unique<StringValueArray>(key, nullptr, rewritable, values_ptr_vector, ' ', mul_conf_argu));
   }
 
   /*------------------------

--- a/src/config.h
+++ b/src/config.h
@@ -14,7 +14,6 @@
 #include <cstddef>
 #include <cstring>
 #include <functional>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <unordered_map>


### PR DESCRIPTION
在配置中添加对不定长参数的支持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

fix #146 

- **New Features**
  - Introduced an updated method for setting values in the configuration, allowing for more flexible handling with an optional check parameter.
  - Added a new public method to check if multiple arguments are allowed for specific configuration keys.
- **Enhancements**
  - Expanded the interface of the `StringValueArray` class with a new constructor parameter, enhancing its functionality.
  - Updated the configuration handling to incorporate a new boolean parameter for better argument management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->