### PR TITLE
fix:ci ubuntu cache miss

### DIFF
--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/*.cpp','**/*.cc','**/*.c', '**/*.h') }}-${{ matrix.compiler || 'gcc' }}
+          key: ${{ runner.os }}-ccache-${{ hashFiles('**/*.cpp','**/*.cc','**/*.c', '**/*.h') }}
           restore-keys: |
             ${{ runner.os }}-ccache-
             ccache-


### PR DESCRIPTION
修复 CI中 Ubuntu ccache key 找不到的错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for build process
	- Modified caching strategy for build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->