### PR TITLE
fix: ccache compile fail

### DIFF
--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           path: |
             ~/.ccache
-            ~/download
+            ${{ github.workspace }}/download
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-clang
 
       - name: Build
@@ -119,7 +119,7 @@ jobs:
         with:
           path: |
             ~/.ccache
-            ~/download
+            ${{ github.workspace }}/download
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
 
       - name: Build

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -40,9 +40,6 @@ jobs:
   build_on_macos:
     runs-on: macos-14
     needs: check_format
-    env:
-      CMAKE_C_COMPILER_LAUNCHER: "ccache"
-      CMAKE_CXX_COMPILER_LAUNCHER: "ccache"
 
     steps:
       - uses: actions/checkout@v4
@@ -53,11 +50,13 @@ jobs:
           brew install autoconf
           brew install go
 
-      - name: Restore ccache
+      - name: Restore cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/download
+            ${{ github.workspace }}/build-release
+            ${{ github.workspace }}/deps-release
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-clang
 
       - name: Build
@@ -89,9 +88,6 @@ jobs:
   build_on_ubuntu:
     runs-on: ubuntu-latest
     needs: check_format
-    env:
-      CMAKE_C_COMPILER_LAUNCHER: "ccache"
-      CMAKE_CXX_COMPILER_LAUNCHER: "ccache"
 
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +97,8 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/download
+            ${{ github.workspace }}/build-release
+            ${{ github.workspace }}/deps-release
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
 
       - name: Build

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -57,7 +57,9 @@ jobs:
             ${{ github.workspace }}/download
             ${{ github.workspace }}/build-release
             ${{ github.workspace }}/deps-release
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-clang
+          key: |
+            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
+            ${{ runner.os }}-
 
       - name: Build
         run: |
@@ -71,19 +73,19 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest
 
-#      - name: Run TCL E2e Tests
-#        working-directory: ${{ github.workspace }}
-#        run:
-#          ./etc/script/kiwitests.sh all
-#
-#      - name: Run Go E2E Tests
-#        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
-#        run: |
-#          set +e
-#          cd ../tests
-#          go mod tidy
-#          go test -timeout 15m --ginkgo.v
-#          sh print_log.sh
+      - name: Run TCL E2e Tests
+        working-directory: ${{ github.workspace }}
+        run:
+          ./etc/script/kiwitests.sh all
+
+      - name: Run Go E2E Tests
+        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
+        run: |
+          set +e
+          cd ../tests
+          go mod tidy
+          go test -timeout 15m --ginkgo.v
+          sh print_log.sh
 
   build_on_ubuntu:
     runs-on: ubuntu-latest
@@ -99,7 +101,9 @@ jobs:
             ${{ github.workspace }}/download
             ${{ github.workspace }}/build-release
             ${{ github.workspace }}/deps-release
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
+          key: |
+            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
+            ${{ runner.os }}-
 
       - name: Build
         run: |
@@ -111,16 +115,16 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest
 
-#      - name: Run TCL E2e Tests
-#        working-directory: ${{ github.workspace }}
-#        run:
-#          ./etc/script/kiwitests.sh all
-#
-#      - name: Run Go E2E Tests
-#        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
-#        run: |
-#          set +e
-#          cd ../tests
-#          go mod tidy
-#          go test -timeout 15m --ginkgo.v || exit 1
-#          sh print_log.sh
+      - name: Run TCL E2e Tests
+        working-directory: ${{ github.workspace }}
+        run:
+          ./etc/script/kiwitests.sh all
+
+      - name: Run Go E2E Tests
+        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
+        run: |
+          set +e
+          cd ../tests
+          go mod tidy
+          go test -timeout 15m --ginkgo.v || exit 1
+          sh print_log.sh

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -50,20 +50,13 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install ccache
           brew install autoconf
           brew install go
-
-      - name: Configure ccache
-        run: |
-          ccache --set-config=cache_dir=$HOME/.ccache
-          ccache --max-size=10G
 
       - name: Restore ccache
         uses: actions/cache@v4
         with:
           path: |
-            ~/.ccache
             ${{ github.workspace }}/download
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-clang
 
@@ -72,9 +65,6 @@ jobs:
           export LIBRARY_PATH=$(xcrun --show-sdk-path)/usr/lib
           export DYLD_LIBRARY_PATH=$(xcrun --show-sdk-path)/usr/lib
           bash ./etc/script/build.sh --verbose
-
-      - name: Save ccache stats
-        run: ccache -s
 
       - name: GTest
         working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
@@ -106,28 +96,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: sudo apt install -y ccache
-
-      - name: Configure ccache
-        run: |
-          ccache --set-config=cache_dir=$HOME/.ccache
-          ccache --max-size=10G
-
       - name: Restore ccache
         uses: actions/cache@v4
         with:
           path: |
-            ~/.ccache
             ${{ github.workspace }}/download
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
 
       - name: Build
         run: |
           bash ./etc/script/build.sh --verbose
-
-      - name: Save ccache stats
-        run: ccache -s
 
       - name: GTest
         working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -60,13 +60,12 @@ jobs:
           ccache --max-size=10G
 
       - name: Restore ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/*.cpp','**/*.cc','**/*.c', '**/*.h') }}-clang
-          restore-keys: |
-            ${{ runner.os }}-ccache-
-            ccache-
+          path: |
+            ~/.ccache
+            ~/download
+          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-clang
 
       - name: Build
         run: |
@@ -83,19 +82,19 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest
 
-      - name: Run TCL E2e Tests
-        working-directory: ${{ github.workspace }}
-        run:
-          ./etc/script/kiwitests.sh all
-
-      - name: Run Go E2E Tests
-        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
-        run: |
-          set +e
-          cd ../tests
-          go mod tidy
-          go test -timeout 15m --ginkgo.v
-          sh print_log.sh
+#      - name: Run TCL E2e Tests
+#        working-directory: ${{ github.workspace }}
+#        run:
+#          ./etc/script/kiwitests.sh all
+#
+#      - name: Run Go E2E Tests
+#        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
+#        run: |
+#          set +e
+#          cd ../tests
+#          go mod tidy
+#          go test -timeout 15m --ginkgo.v
+#          sh print_log.sh
 
   build_on_ubuntu:
     runs-on: ubuntu-latest
@@ -116,13 +115,12 @@ jobs:
           ccache --max-size=10G
 
       - name: Restore ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/*.cpp','**/*.cc','**/*.c', '**/*.h') }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-
-            ccache-
+          path: |
+            ~/.ccache
+            ~/download
+          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
 
       - name: Build
         run: |
@@ -137,16 +135,16 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest
 
-      - name: Run TCL E2e Tests
-        working-directory: ${{ github.workspace }}
-        run:
-          ./etc/script/kiwitests.sh all
-
-      - name: Run Go E2E Tests
-        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
-        run: |
-          set +e
-          cd ../tests
-          go mod tidy
-          go test -timeout 15m --ginkgo.v || exit 1
-          sh print_log.sh
+#      - name: Run TCL E2e Tests
+#        working-directory: ${{ github.workspace }}
+#        run:
+#          ./etc/script/kiwitests.sh all
+#
+#      - name: Run Go E2E Tests
+#        working-directory: ${{ github.workspace }}/${{ env.BUILD_DIR }}
+#        run: |
+#          set +e
+#          cd ../tests
+#          go mod tidy
+#          go test -timeout 15m --ginkgo.v || exit 1
+#          sh print_log.sh

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -57,8 +57,7 @@ jobs:
             ${{ github.workspace }}/download
             ${{ github.workspace }}/build-release
             ${{ github.workspace }}/deps-release
-          key: |
-            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
+          key: ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
           restore-keys: |
             ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
             ${{ runner.os }}-cache-
@@ -103,8 +102,7 @@ jobs:
             ${{ github.workspace }}/download
             ${{ github.workspace }}/build-release
             ${{ github.workspace }}/deps-release
-          key: |
-            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
+          key: ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
           restore-keys: |
             ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
             ${{ runner.os }}-cache-

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -59,7 +59,9 @@ jobs:
             ${{ github.workspace }}/deps-release
           key: |
             ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
-            ${{ runner.os }}-
+          restore-keys: |
+            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
+            ${{ runner.os }}-cache-
 
       - name: Build
         run: |
@@ -103,7 +105,9 @@ jobs:
             ${{ github.workspace }}/deps-release
           key: |
             ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
-            ${{ runner.os }}-
+          restore-keys: |
+            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
+            ${{ runner.os }}-cache-
 
       - name: Build
         run: |

--- a/.github/workflows/kiwidb.yml
+++ b/.github/workflows/kiwidb.yml
@@ -59,7 +59,6 @@ jobs:
             ${{ github.workspace }}/deps-release
           key: ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
           restore-keys: |
-            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-clang
             ${{ runner.os }}-cache-
 
       - name: Build
@@ -104,7 +103,6 @@ jobs:
             ${{ github.workspace }}/deps-release
           key: ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
           restore-keys: |
-            ${{ runner.os }}-cache-${{ hashFiles('**/CMakeLists.txt') }}-gcc
             ${{ runner.os }}-cache-
 
       - name: Build


### PR DESCRIPTION
去掉 `ccache`, 改为缓存 `download` `build-release` `deps-release` 这三个目录

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for `kiwidb.yml`
	- Upgraded caching action from v3 to v4
	- Removed `ccache` configuration and usage
	- Modified cache paths and key generation strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->