### PR TITLE
refactor: net event storage structure

### DIFF
--- a/src/net/base_event.h
+++ b/src/net/base_event.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <utility>
 
-#include "callback_function.h"
+#include "connection.h"
 #include "listen_socket.h"
 #include "net_event.h"
 #include "timer.h"
@@ -26,7 +26,7 @@ namespace net {
 class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
  public:
   // Currently, there are two types of multiplexing: epoll and kqueue
-  enum {
+  enum : std::uint8_t {
     EVENT_TYPE_EPOLL = 1,
     EVENT_TYPE_KQUEUE,
   };
@@ -34,7 +34,7 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
   // Whether to enable read/write separation. If read/write separation is enabled,
   // read and write are in different multiplexes.
   // If not, write events need to be processed in read multiplexes
-  enum {
+  enum : std::uint8_t {
     EVENT_MODE_READ = (1 << 0),   // only read
     EVENT_MODE_WRITE = (1 << 1),  // only write
   };
@@ -51,17 +51,17 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
 
   virtual ~BaseEvent() = default;
 
-  // add fd to poll
-  virtual void AddEvent(uint64_t id, int fd, int mask) = 0;
+  // add conn to poll
+  virtual void AddEvent(Connection *conn, int mask) = 0;
 
   // delete fd from poll
   virtual void DelEvent(int fd) = 0;
 
   // add write event
-  virtual void AddWriteEvent(uint64_t id, int fd) = 0;
+  virtual void AddWriteEvent(Connection *conn) = 0;
 
   // delete write event
-  virtual void DelWriteEvent(uint64_t id, int fd) = 0;
+  virtual void DelWriteEvent(Connection *conn) = 0;
 
   // poll event
   virtual void EventPoll() = 0;
@@ -82,19 +82,17 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
 
   int EvFd() const { return evFd_; }
 
-  void SetOnCreate(std::function<void(uint64_t, std::shared_ptr<Connection>)> &&onCreate) {
-    onCreate_ = std::move(onCreate);
-  }
+  void SetOnCreate(std::function<void(std::shared_ptr<Connection>)> &&onCreate) { onCreate_ = std::move(onCreate); }
 
   void SetOnMessage(std::function<void(uint64_t, std::string &&)> &&onMessage) { onMessage_ = std::move(onMessage); }
 
   void SetOnClose(std::function<void(uint64_t, std::string &&)> &&onClose) { onClose_ = std::move(onClose); }
 
-  void SetGetConn(std::function<std::shared_ptr<Connection>(uint64_t)> &&getConn) { getConn_ = std::move(getConn); }
+  // void SetGetConn(std::function<std::shared_ptr<Connection>(uint64_t)> &&getConn) { getConn_ = std::move(getConn); }
 
   int8_t Type() const { return type_; }
 
-  std::shared_ptr<net::ListenSocket> getListenSocket(int fd) {
+  std::shared_ptr<ListenSocket> getListenSocket(int fd) {
     for (const auto &listen : listen_sockets_) {
       if (fd == listen->Fd()) {
         return listen;
@@ -123,7 +121,7 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
   std::vector<std::shared_ptr<ListenSocket>> listen_sockets_;
 
   // callback function when a new connection is created
-  std::function<void(uint64_t, std::shared_ptr<Connection>)> onCreate_;
+  std::function<void(std::shared_ptr<Connection>)> onCreate_;
 
   // callback function when a message is received
   std::function<void(uint64_t, std::string &&)> onMessage_;
@@ -132,7 +130,7 @@ class BaseEvent : public std::enable_shared_from_this<BaseEvent> {
   std::function<void(uint64_t, std::string &&)> onClose_;
 
   // get connection by connID
-  std::function<std::shared_ptr<Connection>(uint64_t)> getConn_;
+  // std::function<std::shared_ptr<Connection>(uint64_t)> getConn_;
 };
 
 }  // namespace net

--- a/src/net/callback_function.h
+++ b/src/net/callback_function.h
@@ -53,23 +53,4 @@ template <typename T>
 requires HasSetFdFunction<T>
 using OnClose = std::function<void(T &, std::string &&)>;
 
-// class BaseEvent;
-
-class NetEvent;
-
-// class SocketAddr;
-
-// Auxiliary structure
-struct Connection {
-  explicit Connection(std::unique_ptr<NetEvent> net_event) : net_event_(std::move(net_event)) {}
-
-  ~Connection() = default;
-
-  std::unique_ptr<NetEvent> net_event_;
-
-  SocketAddr addr_;
-
-  int fd_ = 0;
-};
-
 }  // namespace net

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -18,7 +18,8 @@ class NetEvent;
 // Auxiliary structure
 struct Connection {
   explicit Connection(std::unique_ptr<NetEvent> net_event) : net_event_(std::move(net_event)) {}
-
+  Connection(const Connection&) = delete;
+  Connection& operator=(const Connection&) = delete;
   ~Connection() = default;
 
   std::unique_ptr<NetEvent> net_event_;

--- a/src/net/connection.h
+++ b/src/net/connection.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-present, Arana/Kiwi Community.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "socket_addr.h"
+
+namespace net {
+
+class NetEvent;
+
+// Auxiliary structure
+struct Connection {
+  explicit Connection(std::unique_ptr<NetEvent> net_event) : net_event_(std::move(net_event)) {}
+
+  ~Connection() = default;
+
+  std::unique_ptr<NetEvent> net_event_;
+
+  SocketAddr addr_;
+
+  uint64_t conn_id_ = 0;
+
+  int fd_ = 0;
+};
+
+}  // namespace net

--- a/src/net/epoll_event.cc
+++ b/src/net/epoll_event.cc
@@ -111,6 +111,9 @@ void EpollEvent::EventRead() {
         DoError(events[i], "");
         continue;
       }
+      if (events[i].data.fd == pipeFd_[0]) {
+        continue;
+      }
       Connection *conn = nullptr;
       if (events[i].events & EVENT_READ) {
         // If the event is less than the listen socket, it is a new connection

--- a/src/net/epoll_event.cc
+++ b/src/net/epoll_event.cc
@@ -9,7 +9,6 @@
 
 #ifdef HAVE_EPOLL
 
-#  include "callback_function.h"
 #  include "log.h"
 
 namespace net {
@@ -28,7 +27,7 @@ bool EpollEvent::Init() {
   }
   if (mode_ & EVENT_MODE_READ) {  // Add the listen socket to epoll for read
     for (auto &s : listen_sockets_) {
-      AddEvent(s->Fd(), s->Fd(), EVENT_READ);
+      AddEvent(s->Fd(), EVENT_READ);
     }
   }
   if (pipe(pipeFd_) == -1) {
@@ -36,17 +35,26 @@ bool EpollEvent::Init() {
     return false;
   }
 
-  AddEvent(pipeFd_[0], pipeFd_[0], EVENT_READ);
+  AddEvent(pipeFd_[0], EVENT_READ);
 
   return true;
 }
 
-void EpollEvent::AddEvent(uint64_t id, int fd, int mask) {
-  struct epoll_event ev {};
+void EpollEvent::AddEvent(int fd, int mask) const {
+  epoll_event ev{};
   ev.events = mask;
-  ev.data.u64 = id;
+  ev.data.fd = fd;
   if (epoll_ctl(EvFd(), EPOLL_CTL_ADD, fd, &ev) == -1) {
-    ERROR("AddEvent id:{},EvFd:{},fd:{}, epoll AddEvent error errno:{}", id, EvFd(), fd, errno);
+    ERROR("AddEvent EvFd:{},fd:{}, epoll add error errno:{}", EvFd(), fd, errno);
+  }
+}
+
+void EpollEvent::AddEvent(Connection *conn, int mask) {
+  epoll_event ev{};
+  ev.events = mask;
+  ev.data.ptr = conn;
+  if (epoll_ctl(EvFd(), EPOLL_CTL_ADD, conn->fd_, &ev) == -1) {
+    ERROR("AddEvent id:{},EvFd:{},fd:{}, epoll AddEvent error errno:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
   }
 }
 
@@ -60,40 +68,37 @@ void EpollEvent::EventPoll() {
   }
 }
 
-void EpollEvent::AddWriteEvent(uint64_t id, int fd) {
-  struct epoll_event ev {};
+void EpollEvent::AddWriteEvent(Connection *conn) {
+  epoll_event ev{};
   ev.events = EVENT_WRITE;
-  ev.data.u64 = id;
+  ev.data.ptr = conn;
   if (mode_ & EVENT_MODE_READ) {  // If it is a read multiplex, modify the event
     ev.events |= EVENT_READ;
-    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
-      ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add RW error errno:{}", id, EvFd(), fd, errno);
+    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, conn->fd_, &ev) == -1) {
+      ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add RW error errno:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
     }
   } else {  // If it is a write multiplex, add the event
-    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
-      ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add W error errno:{}", id, EvFd(), fd, errno);
+    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, conn->fd_, &ev) == -1) {
+      ERROR("AddWriteEvent id:{},EvFd:{},fd:{}, epoll add W error errno:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
     }
   }
 }
 
-void EpollEvent::DelWriteEvent(uint64_t id, int fd) {
-  struct epoll_event ev {};
-  ev.data.u64 = id;
+void EpollEvent::DelWriteEvent(Connection *conn) {
+  epoll_event ev{};
+  ev.data.ptr = conn;
   if (mode_ & EVENT_MODE_READ) {  // If it is a read multiplex, modify the event to rea
     ev.events = EVENT_READ;
-    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
-      ERROR("DelWriteEvent id:{},EvFd:{},fd:{}, EPOLL_CTL_MOD error errno:{}", id, EvFd(), fd, errno);
-    }
   } else {
-    ev.events = BaseEvent::EVENT_NULL;
-    if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, fd, &ev) == -1) {
-      ERROR("DelWriteEvent id:{},EvFd:{},fd:{}, EPOLL_CTL_DEL error errno:{}", id, EvFd(), fd, errno);
-    }
+    ev.events = EVENT_NULL;  // If it is a only write fd,set null event
+  }
+  if (epoll_ctl(EvFd(), EPOLL_CTL_MOD, conn->fd_, &ev) == -1) {
+    ERROR("DelWriteEvent id:{},EvFd:{},fd:{}, EPOLL_CTL_MOD error errno:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
   }
 }
 
 void EpollEvent::EventRead() {
-  struct epoll_event events[eventsSize];
+  epoll_event events[eventsSize];
   int waitInterval = -1;
   if (timer_) {
     waitInterval = static_cast<int>(timer_->Interval());
@@ -106,18 +111,19 @@ void EpollEvent::EventRead() {
         DoError(events[i], "");
         continue;
       }
-      std::shared_ptr<Connection> conn;
+      Connection *conn = nullptr;
       if (events[i].events & EVENT_READ) {
         // If the event is less than the listen socket, it is a new connection
         // If getListenSocket is nullptr, it means the event is not a listen socket
-        if (!getListenSocket(events[i].data.u64)) {
-          conn = getConn_(events[i].data.u64);
+        auto listen = getListenSocket(events[i].data.fd);
+        if (!listen) {
+          conn = static_cast<Connection *>(events[i].data.ptr);
         }
-        DoRead(events[i], conn);
+        DoRead(events[i], conn, listen);
       }
 
       if ((mode_ & EVENT_MODE_WRITE) && events[i].events & EVENT_WRITE) {
-        conn = getConn_(events[i].data.u64);
+        conn = static_cast<Connection *>(events[i].data.ptr);
         if (!conn) {  // If the connection is empty, call DoError
           DoError(events[i], "connection is null");
           continue;
@@ -133,14 +139,14 @@ void EpollEvent::EventRead() {
 }
 
 void EpollEvent::EventWrite() {
-  struct epoll_event events[eventsSize];
+  epoll_event events[eventsSize];
   while (running_.load()) {
     int nfds = epoll_wait(EvFd(), events, eventsSize, -1);
     for (int i = 0; i < nfds; ++i) {
       if ((events[i].events & EVENT_HUB) || (events[i].events & EVENT_ERROR)) {
         DoError(events[i], "");
       }
-      auto conn = getConn_(events[i].data.u64);
+      auto conn = static_cast<Connection *>(events[i].data.ptr);
       if (!conn) {
         DoError(events[i], "connection is null");
         continue;
@@ -152,16 +158,18 @@ void EpollEvent::EventWrite() {
   }
 }
 
-void EpollEvent::DoRead(const epoll_event &event, const std::shared_ptr<Connection> &conn) {
-  if (auto s = getListenSocket(event.data.u64); s) {
+void EpollEvent::DoRead(const epoll_event &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen) {
+  if (listen) {
     auto newConn = std::make_shared<Connection>(nullptr);
-    auto connFd = s->OnReadable(newConn, nullptr);
+    auto connFd = listen->OnReadable(newConn.get(), nullptr);
     if (connFd < 0) {
       DoError(event, "accept error");
       return;
     }
-    onCreate_(connFd, newConn);
-  } else if (conn) {
+    onCreate_(newConn);
+    return;
+  }
+  if (conn) {
     std::string readBuff;
     int ret = conn->net_event_->OnReadable(conn, &readBuff);
     if (ret == NE_ERROR) {
@@ -172,20 +180,27 @@ void EpollEvent::DoRead(const epoll_event &event, const std::shared_ptr<Connecti
       DoError(event, "");
       return;
     }
-    onMessage_(event.data.u64, std::move(readBuff));
+    onMessage_(conn->conn_id_, std::move(readBuff));
   } else {
     DoError(event, "connection is null");
   }
 }
 
-void EpollEvent::DoWrite(const epoll_event &event, const std::shared_ptr<Connection> &conn) {
-  auto ret = conn->net_event_->OnWritable(event.data.u64, conn->fd_, this);
+void EpollEvent::DoWrite(const epoll_event &event, Connection *conn) {
+  auto ret = conn->net_event_->OnWritable(conn, this);
   if (ret == NE_ERROR) {
     DoError(event, "write error,errno: " + std::to_string(errno));
   }
 }
 
-void EpollEvent::DoError(const epoll_event &event, std::string &&err) { onClose_(event.data.u64, std::move(err)); }
+void EpollEvent::DoError(const epoll_event &event, std::string &&err) {
+  auto conn = static_cast<Connection *>(event.data.ptr);
+  if (!conn) {
+    ERROR("DoError conn is null");
+    return;
+  }
+  onClose_(conn->conn_id_, std::move(err));
+}
 
 }  // namespace net
 #endif

--- a/src/net/epoll_event.h
+++ b/src/net/epoll_event.h
@@ -31,8 +31,11 @@ class EpollEvent : public BaseEvent {
   // Initialize the epoll event
   bool Init() override;
 
+  // add fd to poll
+  void AddEvent(int fd, int mask) const;
+
   // Add event to epoll, mask is the event type
-  void AddEvent(uint64_t id, int fd, int mask) override;
+  void AddEvent(Connection *conn, int mask) override;
 
   // Delete event from epoll
   void DelEvent(int fd) override;
@@ -41,10 +44,10 @@ class EpollEvent : public BaseEvent {
   void EventPoll() override;
 
   // Add write event to epoll
-  void AddWriteEvent(uint64_t id, int fd) override;
+  void AddWriteEvent(Connection *conn) override;
 
   // Delete write event from epoll
-  void DelWriteEvent(uint64_t id, int fd) override;
+  void DelWriteEvent(Connection *conn) override;
 
   // Handle read event
   void EventRead();
@@ -53,10 +56,10 @@ class EpollEvent : public BaseEvent {
   void EventWrite();
 
   // Do read event
-  void DoRead(const epoll_event &event, const std::shared_ptr<Connection> &conn);
+  void DoRead(const epoll_event &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen);
 
   // Do write event
-  void DoWrite(const epoll_event &event, const std::shared_ptr<Connection> &conn);
+  void DoWrite(const epoll_event &event, Connection *conn);
 
   // Handle error event
   void DoError(const epoll_event &event, std::string &&err);

--- a/src/net/event_server.cc
+++ b/src/net/event_server.cc
@@ -11,6 +11,6 @@ namespace net {
 
 std::atomic<uint64_t> g_connId = 0;
 
-uint64_t getConnId() { return ++g_connId; }
+uint64_t getConnId() { return g_connId.fetch_add(1); }
 
 }  // namespace net

--- a/src/net/io_thread.h
+++ b/src/net/io_thread.h
@@ -32,10 +32,10 @@ class IOThread {
   void Wait();
 
   // Add read event to epoll when send message to client
-  void SetWriteEvent(uint64_t id, int fd) { baseEvent_->AddWriteEvent(id, fd); }
+  void SetWriteEvent(Connection *conn) { baseEvent_->AddWriteEvent(conn); }
 
   // Add new event to epoll when new connection
-  void AddNewEvent(uint64_t connId, int fd, int mask) { baseEvent_->AddEvent(connId, fd, mask); }
+  void AddNewEvent(Connection *conn, int mask) { baseEvent_->AddEvent(conn, mask); }
 
  protected:
   std::atomic<bool> running_ = true;

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -39,15 +39,15 @@ bool KqueueEvent::Init() {
 }
 
 void KqueueEvent::AddEvent(int fd, int mask) const {
-  kevent change{};
+  struct kevent change;
   EV_SET(&change, fd, mask, EV_ADD, 0, 0, nullptr);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
     ERROR("KqueueEvent AddEvent EvFd:{},fd:{}, epoll add error errno:{}", fd, EvFd(), fd, errno);
   }
 }
 
-void KqueueEvent::void AddEvent(Connection *conn, int mask) {
-  kevent change{};
+void KqueueEvent::AddEvent(Connection *conn, int mask) {
+  struct kevent change;
   EV_SET(&change, conn->fd_, mask, EV_ADD, 0, 0, conn);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
     ERROR("KqueueEvent AddEvent id:{},EvFd:{}，fd:{}, kevent error:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
@@ -56,14 +56,14 @@ void KqueueEvent::void AddEvent(Connection *conn, int mask) {
 
 void KqueueEvent::DelEvent(int fd) {
   if (mode_ & EVENT_MODE_READ) {
-    kevent change{};
+    struct kevent change;
     EV_SET(&change, fd, EVENT_READ, EV_DELETE, 0, 0, nullptr);
     if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
       ERROR("KqueueEvent Del read Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
     }
   }
   if (mode_ & EVENT_MODE_WRITE) {
-    kevent change{};
+    struct kevent change;
     EV_SET(&change, fd, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
     if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
       if (errno != ENOENT) {  // If the event does not exist, it will return ENOENT
@@ -76,7 +76,7 @@ void KqueueEvent::DelEvent(int fd) {
 void KqueueEvent::AddWriteEvent(Connection *conn) { AddEvent(conn, EVENT_WRITE); }
 
 void KqueueEvent::DelWriteEvent(Connection *conn) {
-  kevent change{};
+  struct kevent change;
   EV_SET(&change, conn->fd_, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
     ERROR("KqueueEvent Del write Event id:{},EvFd:{}，fd:{}, kevent error:{}", conn->conn_id_, EvFd(), conn->fd_,
@@ -116,7 +116,7 @@ void KqueueEvent::EventRead() {
         if (!listen) {
           conn = static_cast<Connection *>(events[i].udata);
         }
-        DoRead(events[i], conn);
+        DoRead(events[i], conn, listen);
       } else if ((mode_ & EVENT_MODE_WRITE) && events[i].filter == EVENT_WRITE) {
         conn = static_cast<Connection *>(events[i].udata);
         if (!conn) {
@@ -133,7 +133,7 @@ void KqueueEvent::EventRead() {
 }
 
 void KqueueEvent::EventWrite() {
-  kevent events[eventsSize];
+  struct kevent events[eventsSize];
   while (running_.load()) {
     int nev = kevent(EvFd(), nullptr, 0, events, eventsSize, nullptr);
     for (int i = 0; i < nev; ++i) {
@@ -153,7 +153,7 @@ void KqueueEvent::EventWrite() {
   }
 }
 
-void KqueueEvent::DoRead(const kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen) {
+void KqueueEvent::DoRead(const struct kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen) {
   if (listen) {
     auto newConn = std::make_shared<Connection>(nullptr);
     auto connFd = listen->OnReadable(newConn.get(), nullptr);
@@ -181,7 +181,7 @@ void KqueueEvent::DoRead(const kevent &event, Connection *conn, const std::share
   }
 }
 
-void KqueueEvent::DoWrite(const kevent &event, Connection *conn) {
+void KqueueEvent::DoWrite(const struct kevent &event, Connection *conn) {
   auto ret = conn->net_event_->OnWritable(conn, this);
   if (ret == NE_ERROR) {
     DoError(event, "DoWrite error,errno: " + std::to_string(errno));
@@ -189,7 +189,7 @@ void KqueueEvent::DoWrite(const kevent &event, Connection *conn) {
   }
 }
 
-void KqueueEvent::DoError(const kevent &event, std::string &&err) {
+void KqueueEvent::DoError(const struct kevent &event, std::string &&err) {
   auto conn = static_cast<Connection *>(event.udata);
   if (!conn) {
     ERROR("DoError conn is null");

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -26,7 +26,7 @@ bool KqueueEvent::Init() {
   }
   if (mode_ & EVENT_MODE_READ) {
     for (auto &listenSocket : listen_sockets_) {
-      AddEvent(listenSocket->Fd(), listenSocket->Fd(), EVENT_READ);
+      AddEvent(listenSocket->Fd(), EVENT_READ);
     }
   }
   if (pipe(pipeFd_) == -1) {
@@ -34,34 +34,36 @@ bool KqueueEvent::Init() {
     return false;
   }
 
-  AddEvent(0, pipeFd_[0], EVENT_READ);
+  AddEvent(pipeFd_[0], EVENT_READ);
   return true;
 }
 
-void KqueueEvent::AddEvent(uint64_t id, int fd, int mask) {
-  struct kevent change;
-#  ifdef HAVE_64BIT
-  uint64_t udata = id;
-#  else
-  uint64_t *udata = new uint64_t;
-  *udata = id;
-#  endif
-  EV_SET(&change, fd, mask, EV_ADD, 0, 0, reinterpret_cast<void *>(udata));
+void KqueueEvent::AddEvent(int fd, int mask) const {
+  kevent change{};
+  EV_SET(&change, fd, mask, EV_ADD, 0, 0, nullptr);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
-    ERROR("KqueueEvent AddEvent id:{},EvFd:{}，fd:{}, kevent error:{}", id, EvFd(), fd, errno);
+    ERROR("KqueueEvent AddEvent EvFd:{},fd:{}, epoll add error errno:{}", fd, EvFd(), fd, errno);
+  }
+}
+
+void KqueueEvent::void AddEvent(Connection *conn, int mask) {
+  kevent change{};
+  EV_SET(&change, conn->fd_, mask, EV_ADD, 0, 0, conn);
+  if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
+    ERROR("KqueueEvent AddEvent id:{},EvFd:{}，fd:{}, kevent error:{}", conn->conn_id_, EvFd(), conn->fd_, errno);
   }
 }
 
 void KqueueEvent::DelEvent(int fd) {
   if (mode_ & EVENT_MODE_READ) {
-    struct kevent change;
+    kevent change{};
     EV_SET(&change, fd, EVENT_READ, EV_DELETE, 0, 0, nullptr);
     if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
       ERROR("KqueueEvent Del read Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
     }
   }
   if (mode_ & EVENT_MODE_WRITE) {
-    struct kevent change;
+    kevent change{};
     EV_SET(&change, fd, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
     if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
       if (errno != ENOENT) {  // If the event does not exist, it will return ENOENT
@@ -71,13 +73,14 @@ void KqueueEvent::DelEvent(int fd) {
   }
 }
 
-void KqueueEvent::AddWriteEvent(uint64_t id, int fd) { AddEvent(id, fd, EVENT_WRITE); }
+void KqueueEvent::AddWriteEvent(Connection *conn) { AddEvent(conn, EVENT_WRITE); }
 
-void KqueueEvent::DelWriteEvent(uint64_t id, int fd) {
-  struct kevent change;
-  EV_SET(&change, fd, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
+void KqueueEvent::DelWriteEvent(Connection *conn) {
+  kevent change{};
+  EV_SET(&change, conn->fd_, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
-    ERROR("KqueueEvent Del write Event id:{},EvFd:{}，fd:{}, kevent error:{}", id, EvFd(), fd, errno);
+    ERROR("KqueueEvent Del write Event id:{},EvFd:{}，fd:{}, kevent error:{}", conn->conn_id_, EvFd(), conn->fd_,
+          errno);
   }
 }
 
@@ -107,26 +110,15 @@ void KqueueEvent::EventRead() {
         DoError(events[i], "");
         continue;
       }
-      std::shared_ptr<Connection> conn;
+      Connection *conn = nullptr;
       if (events[i].filter == EVENT_READ) {
-        if (!getListenSocket(events[i].ident)) {
-#  ifdef HAVE_64BIT
-          auto connId = reinterpret_cast<uint64_t>(events[i].udata);
-#  else
-          auto _connId = reinterpret_cast<uint64_t *>(events[i].udata);
-          uint64_t connId = *_connId;
-#  endif
-          conn = getConn_(connId);
+        auto listen = getListenSocket(events[i].ident);
+        if (!listen) {
+          conn = static_cast<Connection *>(events[i].udata);
         }
         DoRead(events[i], conn);
       } else if ((mode_ & EVENT_MODE_WRITE) && events[i].filter == EVENT_WRITE) {
-#  ifdef HAVE_64BIT
-        auto connId = reinterpret_cast<uint64_t>(events[i].udata);
-#  else
-        auto _connId = reinterpret_cast<uint64_t *>(events[i].udata);
-        uint64_t connId = *_connId;
-#  endif
-        conn = getConn_(connId);
+        conn = static_cast<Connection *>(events[i].udata);
         if (!conn) {
           DoError(events[i], "write conn is null");
           continue;
@@ -141,7 +133,7 @@ void KqueueEvent::EventRead() {
 }
 
 void KqueueEvent::EventWrite() {
-  struct kevent events[eventsSize];
+  kevent events[eventsSize];
   while (running_.load()) {
     int nev = kevent(EvFd(), nullptr, 0, events, eventsSize, nullptr);
     for (int i = 0; i < nev; ++i) {
@@ -149,13 +141,7 @@ void KqueueEvent::EventWrite() {
         DoError(events[i], "EventWrite error");
         continue;
       }
-#  ifdef HAVE_64BIT
-      auto connId = reinterpret_cast<uint64_t>(events[i].udata);
-#  else
-      auto _connId = reinterpret_cast<uint64_t *>(events[i].udata);
-      uint64_t connId = *_connId;
-#  endif
-      auto conn = getConn_(connId);
+      auto conn = static_cast<Connection *>(events[i].udata);
       if (!conn) {
         DoError(events[i], "write conn is null");
         continue;
@@ -167,57 +153,49 @@ void KqueueEvent::EventWrite() {
   }
 }
 
-void KqueueEvent::DoRead(const struct kevent &event, const std::shared_ptr<Connection> &conn) {
-  if (auto s = getListenSocket(event.ident); s) {
+void KqueueEvent::DoRead(const kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen) {
+  if (listen) {
     auto newConn = std::make_shared<Connection>(nullptr);
-    auto connFd = s->OnReadable(newConn, nullptr);
-    onCreate_(connFd, newConn);
-  } else if (conn) {
+    auto connFd = listen->OnReadable(newConn.get(), nullptr);
+    if (connFd < 0) {
+      DoError(event, "accept error");
+      return;
+    }
+    onCreate_(newConn);
+    return;
+  }
+  if (conn) {
     std::string readBuff;
     int ret = conn->net_event_->OnReadable(conn, &readBuff);
     if (ret == NE_ERROR) {
       DoError(event, "read error,errno: " + std::to_string(errno));
       return;
-    } else if (ret == NE_CLOSE) {
+    }
+    if (ret == NE_CLOSE) {
       DoError(event, "");
       return;
     }
-#  ifdef HAVE_64BIT
-    auto connId = reinterpret_cast<uint64_t>(event.udata);
-#  else
-    auto _connId = reinterpret_cast<uint64_t *>(event.udata);
-    uint64_t connId = *_connId;
-#  endif
-    onMessage_(connId, std::move(readBuff));
+    onMessage_(conn->conn_id_, std::move(readBuff));
   } else {
     DoError(event, "DoRead error");
   }
 }
 
-void KqueueEvent::DoWrite(const struct kevent &event, const std::shared_ptr<Connection> &conn) {
-#  ifdef HAVE_64BIT
-  auto conn_id = reinterpret_cast<uint64_t>(event.udata);
-#  else
-  auto _conn_id = reinterpret_cast<uint64_t *>(event.udata);
-  uint64_t conn_id = *_conn_id;
-  delete _conn_id;
-#  endif
-  auto ret = conn->net_event_->OnWritable(conn_id, conn->fd_, this);
+void KqueueEvent::DoWrite(const kevent &event, Connection *conn) {
+  auto ret = conn->net_event_->OnWritable(conn, this);
   if (ret == NE_ERROR) {
     DoError(event, "DoWrite error,errno: " + std::to_string(errno));
     return;
   }
 }
 
-void KqueueEvent::DoError(const struct kevent &event, std::string &&err) {
-#  ifdef HAVE_64BIT
-  auto connId = reinterpret_cast<uint64_t>(event.udata);
-#  else
-  auto _connId = reinterpret_cast<uint64_t *>(event.udata);
-  uint64_t connId = *_connId;
-  delete _connId;
-#  endif
-  onClose_(connId, std::move(err));
+void KqueueEvent::DoError(const kevent &event, std::string &&err) {
+  auto conn = static_cast<Connection *>(event.udata);
+  if (!conn) {
+    ERROR("DoError conn is null");
+    return;
+  }
+  onClose_(conn->conn_id_, std::move(err));
 }
 
 }  // namespace net

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -110,6 +110,9 @@ void KqueueEvent::EventRead() {
         DoError(events[i], "");
         continue;
       }
+      if (events[i].data.fd == pipeFd_[0]) {
+        continue;
+      }
       Connection *conn = nullptr;
       if (events[i].filter == EVENT_READ) {
         auto listen = getListenSocket(events[i].ident);

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -110,7 +110,7 @@ void KqueueEvent::EventRead() {
         DoError(events[i], "");
         continue;
       }
-      if (events[i].data.fd == pipeFd_[0]) {
+      if (events[i].ident == pipeFd_[0]) {
         continue;
       }
       Connection *conn = nullptr;

--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -42,7 +42,7 @@ void KqueueEvent::AddEvent(int fd, int mask) const {
   struct kevent change;
   EV_SET(&change, fd, mask, EV_ADD, 0, 0, nullptr);
   if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
-    ERROR("KqueueEvent AddEvent EvFd:{},fd:{}, epoll add error errno:{}", fd, EvFd(), fd, errno);
+    ERROR("KqueueEvent AddEvent EvFd:{},fd:{}, epoll add error errno:{}", EvFd(), fd, errno);
   }
 }
 

--- a/src/net/kqueue_event.h
+++ b/src/net/kqueue_event.h
@@ -46,11 +46,11 @@ class KqueueEvent : public BaseEvent {
 
   void EventWrite();
 
-  void DoRead(const kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen);
+  void DoRead(const struct kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen);
 
-  void DoWrite(const kevent &event, Connection *conn);
+  void DoWrite(const struct kevent &event, Connection *conn);
 
-  void DoError(const kevent &event, std::string &&err);
+  void DoError(const struct kevent &event, std::string &&err);
 
  private:
   const int eventsSize = 1024;

--- a/src/net/kqueue_event.h
+++ b/src/net/kqueue_event.h
@@ -30,13 +30,15 @@ class KqueueEvent : public BaseEvent {
 
   bool Init() override;
 
-  void AddEvent(uint64_t id, int fd, int mask) override;
+  void AddEvent(int fd, int mask) const;
+
+  void AddEvent(Connection *conn, int mask) override;
 
   void DelEvent(int fd) override;
 
-  void AddWriteEvent(uint64_t id, int fd) override;
+  void AddWriteEvent(Connection *conn) override;
 
-  void DelWriteEvent(uint64_t id, int fd) override;
+  void DelWriteEvent(Connection *conn) override;
 
   void EventPoll() override;
 
@@ -44,11 +46,11 @@ class KqueueEvent : public BaseEvent {
 
   void EventWrite();
 
-  void DoRead(const struct kevent &event, const std::shared_ptr<Connection> &conn);
+  void DoRead(const kevent &event, Connection *conn, const std::shared_ptr<ListenSocket> &listen);
 
-  void DoWrite(const struct kevent &event, const std::shared_ptr<Connection> &conn);
+  void DoWrite(const kevent &event, Connection *conn);
 
-  void DoError(const struct kevent &event, std::string &&err);
+  void DoError(const kevent &event, std::string &&err);
 
  private:
   const int eventsSize = 1024;

--- a/src/net/listen_socket.cc
+++ b/src/net/listen_socket.cc
@@ -19,8 +19,8 @@ const int ListenSocket::LISTENQ = 1024;
 
 bool ListenSocket::REUSE_PORT = true;
 
-int ListenSocket::OnReadable(const std::shared_ptr<Connection> &conn, std::string *read_buff) {
-  struct sockaddr_in clientAddr {};
+int ListenSocket::OnReadable(Connection *conn, std::string *read_buff) {
+  sockaddr_in clientAddr{};
   auto newConnFd = Accept(&clientAddr);
   if (newConnFd == 0) {
     ERROR("ListenSocket fd:{},Accept error:{}", Fd(), errno);
@@ -40,7 +40,7 @@ int ListenSocket::OnReadable(const std::shared_ptr<Connection> &conn, std::strin
   return newConnFd;
 }
 
-int ListenSocket::OnWritable(uint64_t id, int fd, BaseEvent *event) { return 1; }
+int ListenSocket::OnWritable(Connection *conn, BaseEvent *event) { return 1; }
 
 void ListenSocket::SendPacket(std::string &&msg, std::function<void()> addWriteFlag) {}
 

--- a/src/net/listen_socket.h
+++ b/src/net/listen_socket.h
@@ -30,10 +30,10 @@ class ListenSocket : public BaseSocket {
 
   // Accept new connection and create new connection object
   // when the connection is established, the OnCreate function is called
-  int OnReadable(const std::shared_ptr<Connection> &conn, std::string *read_buff) override;
+  int OnReadable(Connection *conn, std::string *readBuff) override;
 
   // The function is cant be used
-  int OnWritable(uint64_t id, int fd, BaseEvent *event) override;
+  int OnWritable(Connection *conn, BaseEvent *event) override;
 
   // The function is cant be used
   void SendPacket(std::string &&msg, std::function<void()> addWriteFlag) override;

--- a/src/net/net_event.h
+++ b/src/net/net_event.h
@@ -10,18 +10,19 @@
 #include <atomic>
 
 #include "callback_function.h"
+#include "connection.h"
 
 namespace net {
 
 // For human readability
-enum {
+enum : std::int8_t {
   NE_ERROR = -1,
   NE_CLOSE = -2,
   NE_WAIT = -3,
   NE_OK = 0,
 };
 
-enum class NetListen {
+enum class NetListen : std::uint8_t {
   OK = 0,
   OPEN_ERROR,
   BIND_ERROR,
@@ -41,10 +42,10 @@ class NetEvent {
   virtual int Init() = 0;
 
   // Handle read event when the connection is readable and the data can be read
-  virtual int OnReadable(const std::shared_ptr<Connection> &conn, std::string *readBuff) = 0;
+  virtual int OnReadable(Connection *conn, std::string *readBuff) = 0;
 
   // Handle write event when the connection is writable and the data can be sent
-  virtual int OnWritable(uint64_t id, int fd, BaseEvent *event) = 0;
+  virtual int OnWritable(Connection *conn, BaseEvent *event) = 0;
 
   virtual void OnError() = 0;
 

--- a/src/net/socket_addr.h
+++ b/src/net/socket_addr.h
@@ -46,6 +46,7 @@ struct SocketAddr {
     if (::inet_pton(AF_INET6, ip.c_str(), &addr_.addr6_.sin6_addr) == 1) {
       addr_.addr6_.sin6_family = AF_INET6;
       addr_.addr6_.sin6_port = htons(hostPort);
+      addr_.addr6_.sin6_scope_id = 0;
       return;
     }
     Clear();  // Reset the address if parsing fails

--- a/src/net/stream_socket.cc
+++ b/src/net/stream_socket.cc
@@ -11,16 +11,16 @@
 
 namespace net {
 
-int StreamSocket::OnReadable(const std::shared_ptr<Connection> &conn, std::string *readBuff) { return Read(readBuff); }
+int StreamSocket::OnReadable(Connection *conn, std::string *readBuff) { return Read(readBuff); }
 
 // return bytes that have not yet been sent
-int StreamSocket::OnWritable(uint64_t id, int fd, BaseEvent *event) {
+int StreamSocket::OnWritable(Connection *conn, BaseEvent *event) {
   if (sendData_.empty()) {
     if (!writeQueue_.Pop(sendData_)) {  // no data to send
       std::lock_guard lock(write_mutex_);
       if (writeQueue_.Empty()) {  // double check
         writeReady_ = false;
-        event->DelWriteEvent(id, fd);
+        event->DelWriteEvent(conn);
       }
     }
     return NE_OK;
@@ -43,7 +43,7 @@ int StreamSocket::OnWritable(uint64_t id, int fd, BaseEvent *event) {
       std::lock_guard lock(write_mutex_);
       if (writeQueue_.Empty()) {  // double check
         writeReady_ = false;
-        event->DelWriteEvent(id, fd);
+        event->DelWriteEvent(conn);
       }
       return NE_OK;
     }

--- a/src/net/stream_socket.h
+++ b/src/net/stream_socket.h
@@ -25,9 +25,9 @@ class StreamSocket : public BaseSocket {
 
   int Init() override { return 1; };
 
-  int OnReadable(const std::shared_ptr<Connection> &conn, std::string *readBuff) override;
+  int OnReadable(Connection *conn, std::string *readBuff) override;
 
-  int OnWritable(uint64_t id, int fd, BaseEvent *event) override;
+  int OnWritable(Connection *conn, BaseEvent *event) override;
 
   void SendPacket(std::string &&msg, std::function<void()> addWriteFlag) override;
 

--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -16,7 +16,9 @@
 
 #include "callback_function.h"
 #include "config.h"
+#include "connection.h"
 #include "io_thread.h"
+#include "log.h"
 #include "net_options.h"
 
 #include "log.h"
@@ -64,7 +66,7 @@ class ThreadManager {
   void Stop();
 
   // Create a new connection callback function
-  void OnNetEventCreate(int fd, const std::shared_ptr<Connection> &conn);
+  void OnNetEventCreate(const std::shared_ptr<Connection> &conn);
 
   // Read message callback function
   void OnNetEventMessage(uint64_t conn_id, std::string &&read_data);
@@ -159,19 +161,20 @@ void ThreadManager<T>::Stop() {
 
 template <typename T>
 requires HasSetFdFunction<T>
-void ThreadManager<T>::OnNetEventCreate(int fd, const std::shared_ptr<Connection> &conn) {
+void ThreadManager<T>::OnNetEventCreate(const std::shared_ptr<Connection> &conn) {
   uint32_t expected = get_client_count();
+  conn->fd_;
   if (!client_count_.compare_exchange_strong(expected, expected + 1, std::memory_order_seq_cst,
                                              std::memory_order_seq_cst) ||
       expected >= net_options_.GetMaxClients()) {
-    INFO("Max client connections, refuse new connection fd:{}", fd);
+    INFO("Max client connections, refuse new connection fd:{}", conn->fd_);
     std::string response = "-ERR max clients reached\r\n";
-    ssize_t sent = ::send(fd, response.c_str(), response.size(), 0);
+    ssize_t sent = ::send(conn->fd_, response.c_str(), response.size(), 0);
     if (sent < 0) {
-      ERROR("Failed to send error response to fd: %d, errno: %d", fd, errno);
+      ERROR("Failed to send error response to fd: %d, errno: %d", conn->fd_, errno);
     }
-    if (::close(fd) < 0) {
-      ERROR("Failed to close fd: %d, errno: %d", fd, errno);
+    if (::close(conn->fd_) < 0) {
+      ERROR("Failed to close fd: %d, errno: %d", conn->fd_, errno);
     }
     return;
   }
@@ -191,11 +194,12 @@ void ThreadManager<T>::OnNetEventCreate(int fd, const std::shared_ptr<Connection
     std::lock_guard lock(mutex_);
     connections_.emplace(conn_id, std::make_pair(t, conn));
   }
-  read_thread_->AddNewEvent(conn_id, fd, BaseEvent::EVENT_READ);
+  read_thread_->AddNewEvent(conn.get(), BaseEvent::EVENT_READ);
   if (write_thread_) {
-    write_thread_->AddNewEvent(conn_id, fd, BaseEvent::EVENT_NULL);  // add null event to write_thread epoll
+    write_thread_->AddNewEvent(conn.get(), BaseEvent::EVENT_NULL);  // add null event to write_thread epoll
   }
 
+  conn->conn_id_ = conn_id;
   on_create_(conn_id, t, conn->addr_);
 }
 
@@ -207,6 +211,7 @@ void ThreadManager<T>::OnNetEventMessage(uint64_t conn_id, std::string &&read_da
     std::shared_lock lock(mutex_);
     auto iter = connections_.find(conn_id);
     if (iter == connections_.end()) {
+      ERROR("OnNetEventMessage conn_id:{} not found", conn_id);
       return;
     }
     t = iter->second.first;
@@ -217,13 +222,13 @@ void ThreadManager<T>::OnNetEventMessage(uint64_t conn_id, std::string &&read_da
 template <typename T>
 requires HasSetFdFunction<T>
 void ThreadManager<T>::OnNetEventClose(uint64_t conn_id, std::string &&err) {
-  int fd;
   std::lock_guard lock(mutex_);
   auto iter = connections_.find(conn_id);
   if (iter == connections_.end()) {
+    ERROR("OnNetEventClose conn_id:{} not found", conn_id);
     return;
   }
-  fd = iter->second.second->fd_;
+  const int fd = iter->second.second->fd_;
 
   read_thread_->CloseConnection(fd);
   if (net_options_.GetRwSeparation()) {
@@ -294,9 +299,9 @@ void ThreadManager<T>::SendPacket(const T &conn, std::string &&msg) {
 
   conn_ptr->net_event_->SendPacket(std::move(msg), [&]() {
     if (net_options_.GetRwSeparation()) {
-      write_thread_->SetWriteEvent(conn_id, conn_ptr->fd_);
+      write_thread_->SetWriteEvent(conn_ptr.get());
     } else {
-      read_thread_->SetWriteEvent(conn_id, conn_ptr->fd_);
+      read_thread_->SetWriteEvent(conn_ptr.get());
     }
   });
 }
@@ -319,22 +324,12 @@ bool ThreadManager<T>::CreateReadThread(const std::vector<std::shared_ptr<Listen
 
   event->AddTimer(timer);
 
-  event->SetOnCreate(
-      [this](uint64_t conn_id, const std::shared_ptr<Connection> &conn) { OnNetEventCreate(conn_id, conn); });
+  event->SetOnCreate([this](const std::shared_ptr<Connection> &conn) { OnNetEventCreate(conn); });
 
   event->SetOnMessage(
       [this](uint64_t conn_id, std::string &&read_data) { OnNetEventMessage(conn_id, std::move(read_data)); });
 
   event->SetOnClose([this](uint64_t conn_id, std::string &&err) { OnNetEventClose(conn_id, std::move(err)); });
-
-  event->SetGetConn([this](uint64_t conn_id) -> std::shared_ptr<Connection> {
-    std::shared_lock lock(mutex_);
-    auto iter = connections_.find(conn_id);
-    if (iter == connections_.end()) {
-      return nullptr;
-    }
-    return iter->second.second;
-  });
 
   read_thread_ = std::make_unique<IOThread>(event);
   return read_thread_->Run();
@@ -352,14 +347,6 @@ bool ThreadManager<T>::CreateWriteThread() {
 #endif
 
   event->SetOnClose([this](uint64_t conn_id, std::string &&msg) { OnNetEventClose(conn_id, std::move(msg)); });
-  event->SetGetConn([this](uint64_t conn_id) -> std::shared_ptr<Connection> {
-    std::shared_lock lock(mutex_);
-    auto iter = connections_.find(conn_id);
-    if (iter == connections_.end()) {
-      return nullptr;
-    }
-    return iter->second.second;
-  });
 
   write_thread_ = std::make_unique<IOThread>(event);
   return write_thread_->Run();
@@ -383,9 +370,9 @@ uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd, const std::shared_ptr<Conn
     connections_.emplace(conn_id, std::make_pair(t, conn));
   }
 
-  read_thread_->AddNewEvent(conn_id, fd, BaseEvent::EVENT_READ);
+  read_thread_->AddNewEvent(conn.get(), BaseEvent::EVENT_READ);
   if (write_thread_) {
-    write_thread_->AddNewEvent(conn_id, fd, BaseEvent::EVENT_NULL);  // add null event to write_thread epoll
+    write_thread_->AddNewEvent(conn.get(), BaseEvent::EVENT_NULL);  // add null event to write_thread epoll
   }
   return conn_id;
 }


### PR DESCRIPTION
修改网络层event在操作系统事件通知 (epoll/kevent) 中存储的结构

以前存储的是自增id, 现在存储指针

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an improved connection abstraction to simplify network event interactions.

- **Refactor**
  - Streamlined event handling interfaces by shifting from separate identifiers to direct connection references, enhancing type safety and clarity.
  - Consolidated connection management across networking components for a more uniform interface.

- **Chore**
  - Updated thread and atomic operation mechanisms to improve performance and reliability in network event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->