### PR TITLE
upgrade: rocksdb to 9.11.0

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -12,7 +12,7 @@ ExternalProject_Add(
         ${EXTERNAL_PROJECT_LOG_ARGS}
         DEPENDS gflags snappy zlib lz4 zstd
         GIT_REPOSITORY https://github.com/facebook/rocksdb.git
-        GIT_TAG v9.4.0
+        GIT_TAG v9.11.0
         GIT_SHALLOW true
         SOURCE_DIR ${ROCKSDB_SOURCES_DIR}
         CMAKE_ARGS

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -12,7 +12,7 @@ ExternalProject_Add(
         ${EXTERNAL_PROJECT_LOG_ARGS}
         DEPENDS gflags snappy zlib lz4 zstd
         GIT_REPOSITORY https://github.com/facebook/rocksdb.git
-        GIT_TAG v9.11.0
+        GIT_TAG v9.11.1
         GIT_SHALLOW true
         SOURCE_DIR ${ROCKSDB_SOURCES_DIR}
         CMAKE_ARGS

--- a/src/std/noncopyable.h
+++ b/src/std/noncopyable.h
@@ -12,7 +12,7 @@ namespace kstd {
 class noncopyable {
  protected:
   noncopyable() = default;
-  ~noncopyable() = default;
+  virtual ~noncopyable() = default;
 
  private:
   noncopyable(const noncopyable&) = delete;


### PR DESCRIPTION
升级rocksdb 到 9.11.0,解决内存泄漏问题

https://github.com/facebook/rocksdb/releases/tag/v9.10.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded our RocksDB dependency from version 9.4.0 to 9.11.1. This behind-the-scenes update incorporates the latest performance improvements, stability enhancements, and bug fixes. Although the change is not directly visible in the interface, it helps ensure a smoother and more reliable experience overall.
- **Bug Fixes**
	- Updated the destructor of the noncopyable class to be virtual, improving memory management and object lifecycle handling in inheritance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->