### PR TITLE
fix: raft join failed

### DIFF
--- a/src/net/thread_manager.h
+++ b/src/net/thread_manager.h
@@ -363,7 +363,9 @@ uint64_t ThreadManager<T>::DoTCPConnect(T &t, int fd, const std::shared_ptr<Conn
     t.SetConnId(conn_id);
     t.SetThreadIndex(index_);
   }
+
   conn->fd_ = fd;
+  conn->conn_id_ = conn_id;
 
   {
     std::lock_guard lock(mutex_);


### PR DESCRIPTION
这里的conn_id忘设置，导致发送信息时找不到conn
closed#216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced connection management to improve operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->