### PR TITLE
feat: support the gflags for cmd parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Kiwi is compiled by default in release mode, which does not support debugging. I
 ## Run
 
 ```bash
-./bin/kiwi --config ./etc/conf/kiwi.conf
+./bin/kiwi [--config] ./etc/conf/kiwi.conf
 ```
 
 ## Support module for write your own extensions

--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ Kiwi is compiled by default in release mode, which does not support debugging. I
 ./etc/script/build.sh --debug
 ```
 
+## Usage
+
+```bash
+./bin/kiwi --usage
+```
+
 ## Run
 
 ```bash
-./bin/kiwi ./etc/conf/kiwi.conf
+./bin/kiwi --config ./etc/conf/kiwi.conf
 ```
 
 ## Support module for write your own extensions

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -525,7 +525,9 @@ int main(int argc, char* argv[]) {
     Usage();
     return -1;
   }
+#if BUILD_DEBUG
   PrintParsedFlags();
+#endif  //! BUILD_DEBUG
 
   if (!g_kiwi->GetConfigName().empty()) {
     if (!g_config.LoadFromFile(g_kiwi->GetConfigName())) {

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -83,6 +83,9 @@ static void Usage() {
   std::cerr << "  --ips                           List of IP addresses [x.x.x.x ::x::x::x::x ...]\n";
   std::cerr << "  --config                        Path to the configuration file\n";
   std::cerr << "Examples:\n";
+  std::cerr << "  kiwi --usage\n";
+  std::cerr << "  kiwi --Version\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf\n";
   std::cerr << "  kiwi [--config] /path/kiwi.conf\n";
   std::cerr << "  kiwi [--config] /path/kiwi.conf --loglevel verbose\n";
   std::cerr << "  kiwi --port 7777\n";
@@ -181,7 +184,8 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
 
   if (FLAGS_port > 0) {
     if (FLAGS_port <= 1234) {
-      std::cerr << "You should have root privileges but now NOT support." << "\n";
+      std::cerr << "You should have root privileges but now NOT support."
+                << "\n";
       return false;
     }
     port_ = static_cast<uint16_t>(FLAGS_port);
@@ -190,7 +194,8 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
   if (!FLAGS_loglevel.empty()) {
     if (FLAGS_loglevel != "debug" && FLAGS_loglevel != "verbose" && FLAGS_loglevel != "notice" &&
         FLAGS_loglevel != "warning") {
-      std::cerr << "You must be choose one of [debug, verbose, notice, warning]." << "\n";
+      std::cerr << "You must be choose one of [debug, verbose, notice, warning]."
+                << "\n";
       return false;
     }
     options_.SetLogLevel(FLAGS_loglevel);
@@ -213,7 +218,8 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
     std::transform(FLAGS_use_raft.cbegin(), FLAGS_use_raft.cend(), FLAGS_use_raft.begin(),
                    [](unsigned char c) { return std::tolower(c); });
     if (FLAGS_use_raft != "yes" && FLAGS_use_raft != "no") {
-      std::cerr << "You should decide use-raft = yes or no" << "\n";
+      std::cerr << "You should decide use-raft = yes or no"
+                << "\n";
       return false;
     }
     options_.SetUseRaft(FLAGS_use_raft);

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -75,7 +75,7 @@ static void Usage() {
   std::cerr << "  -v, --Version                   output version information, then exit\n";
   std::cerr << "  -h, --usage                     output help message\n";
   std::cerr << "  -p PORT, --port PORT            Set the port to listen on\n";
-  std::cerr << "  -l LEVEL, --loglevel LEVEL      Set the log level (e.g., info, debug, error)\n";
+  std::cerr << "  -l LEVEL, --loglevel LEVEL      Set the log level (e.g., debug, verbose, notice, warning)\n";
   std::cerr << "  -s ADDRESS, --slaveof ADDRESS   Set the slave address (e.g., 127.0.0.1:6380)\n";
   std::cerr << "  -c, --redis-compatible-mode     Enable Redis compatibility mode\n";
   std::cerr << "  --use-raft                      Whether to use Raft [yes or no]\n";

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -358,7 +358,7 @@ bool KiwiDB::Init() {
   }
 
   if (!options_.GetUseRaft().empty()) {
-    g_config.Set("use-raft", "yes", true);
+    g_config.Set("use-raft", options_.GetUseRaft(), true);
   }
 
   if (!options_.GetRaftIp().empty()) {

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -83,13 +83,13 @@ static void Usage() {
   std::cerr << "  --ips                           List of IP addresses [x.x.x.x ::x::x::x::x ...]\n";
   std::cerr << "  --config                        Path to the configuration file\n";
   std::cerr << "Examples:\n";
-  std::cerr << "  kiwi /path/kiwi.conf\n";
-  std::cerr << "  kiwi /path/kiwi.conf --loglevel verbose\n";
+  std::cerr << "  kiwi --config /path/kiwi.conf\n";
+  std::cerr << "  kiwi --config /path/kiwi.conf --loglevel verbose\n";
   std::cerr << "  kiwi --port 7777\n";
   std::cerr << "  kiwi --port 7777 --slaveof 127.0.0.1:8888\n";
-  std::cerr << "  kiwi /path/kiwi.conf --use_raft [yes or no]\n";
-  std::cerr << "  kiwi /path/kiwi.conf --ips [x.x.x.x ::x::x::x::x ...]\n";
-  std::cerr << "  kiwi /path/kiwi.conf --raft_ip x.x.x.x\n";
+  std::cerr << "  kiwi --config /path/kiwi.conf --use_raft [yes or no]\n";
+  std::cerr << "  kiwi --config /path/kiwi.conf --ips [x.x.x.x ::x::x::x::x ...]\n";
+  std::cerr << "  kiwi --config /path/kiwi.conf --raft_ip x.x.x.x\n";
 }
 
 static void version() {

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -18,11 +18,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 
 #include "client.h"
 #include "client_map.h"
 #include "config.h"
+#include "gflags/gflags.h"
 #include "helper.h"
 #include "kiwi.h"
 #include "kiwi_logo.h"
@@ -70,17 +72,24 @@ static void Usage() {
   std::cerr << "  kiwi [/path/to/kiwi.conf] [options]\n";
   std::cerr << "\n";
   std::cerr << "Options:\n";
-  std::cerr << "  -v, --version                   output version information, then exit\n";
-  std::cerr << "  -h, --help                      output help message\n";
-  std::cerr << "  -p PORT, --port PORT            Set the port listen on\n";
-  std::cerr << "  -l LEVEL, --loglevel LEVEL      Set the log level\n";
-  std::cerr << "  -s ADDRESS, --slaveof ADDRESS   Set the slave address\n";
-  std::cerr << "  -c, --redis-compatible-mode     Enable Redis compatibility mode\n";
+  std::cerr << "  -v, --Version                   output version information, then exit\n";
+  std::cerr << "  -h, --usage                     output help message\n";
+  std::cerr << "  -p PORT, --port PORT            Set the port to listen on\n";
+  std::cerr << "  -l LEVEL, --loglevel LEVEL      Set the log level (e.g., info, debug, error)\n";
+  std::cerr << "  -s ADDRESS, --slaveof ADDRESS   Set the slave address (e.g., 127.0.0.1:6380)\n";
+  std::cerr << "  -c, --redis_compatible_mode     Enable Redis compatibility mode\n";
+  std::cerr << "  --use_raft                      Whether to use Raft [yes or no]\n";
+  std::cerr << "  --raft_ip                       Raft IP address\n";
+  std::cerr << "  --ips                           List of IP addresses [x.x.x.x ::x::x::x::x ...]\n";
+  std::cerr << "  --config                        Path to the configuration file\n";
   std::cerr << "Examples:\n";
   std::cerr << "  kiwi /path/kiwi.conf\n";
   std::cerr << "  kiwi /path/kiwi.conf --loglevel verbose\n";
   std::cerr << "  kiwi --port 7777\n";
   std::cerr << "  kiwi --port 7777 --slaveof 127.0.0.1:8888\n";
+  std::cerr << "  kiwi /path/kiwi.conf --use_raft [yes or no]\n";
+  std::cerr << "  kiwi /path/kiwi.conf --ips [x.x.x.x ::x::x::x::x ...]\n";
+  std::cerr << "  kiwi /path/kiwi.conf --raft_ip x.x.x.x\n";
 }
 
 static void version() {
@@ -90,94 +99,185 @@ static void version() {
   std::cerr << "kiwi Server Build GIT SHA: " << KIWI_GIT_COMMIT_ID << '\n';
 }
 
-// Handle the argc & argv
-bool KiwiDB::ParseArgs(int argc, char* argv[]) {
-  static struct option long_options[] = {
-      {.name = "version", .has_arg = no_argument, .flag = nullptr, .val = 'v'},
-      {.name = "help", .has_arg = no_argument, .flag = nullptr, .val = 'h'},
-      {.name = "port", .has_arg = required_argument, .flag = nullptr, .val = 'p'},
-      {.name = "loglevel", .has_arg = required_argument, .flag = nullptr, .val = 'l'},
-      {.name = "slaveof", .has_arg = required_argument, .flag = nullptr, .val = 's'},
-      {.name = "redis-compatible-mode", .has_arg = no_argument, .flag = nullptr, .val = 'c'},
-  };
-  // kiwi [/path/to/kiwi.conf] [options]
-  if (argv == nullptr) {
+DEFINE_string(config, "", "Path to the configuration file");
+DEFINE_string(use_raft, "", "Whether to use Raft [yes or no]");
+DEFINE_string(ips, "", "List of IP addresses [x.x.x.x ::x::x::x::x ...]");
+DEFINE_string(raft_ip, "", "Raft IP address");
+DEFINE_uint32(port, 0, "Port number");
+DEFINE_string(loglevel, "", "Log level");
+DEFINE_bool(redis_compatible_mode, false, "Enable Redis compatible mode");
+DEFINE_string(slaveof, "", "Set as a slave of another instance");
+DEFINE_bool(usage, false, "Show usage information");
+DEFINE_bool(Version, false, "Show version information");
+
+static inline std::vector<std::string> SplitIPs(const std::string& ips, const std::string& sep) {
+  std::vector<std::string> ipList;
+  size_t start = 0;
+  size_t end = ips.find(sep);
+  while (end != std::string::npos) {
+    ipList.push_back(ips.substr(start, end - start));
+    start = end + sep.size();
+    end = ips.find(sep, start);
+  }
+  ipList.emplace_back(ips.substr(start, end));
+  return ipList;
+}
+
+static inline void PrintParsedFlags() {
+  std::cout << "Parsed command-line flags:\n";
+  std::cout << "  --config: " << FLAGS_config << "\n";
+  std::cout << "  --use_raft: " << FLAGS_use_raft << "\n";
+  std::cout << "  --ips: " << FLAGS_ips << "\n";
+  std::cout << "  --raft_ip: " << FLAGS_raft_ip << "\n";
+  std::cout << "  --port: " << FLAGS_port << "\n";
+  std::cout << "  --loglevel: " << FLAGS_loglevel << "\n";
+  std::cout << "  --redis_compatible_mode: " << (FLAGS_redis_compatible_mode ? "true" : "false") << "\n";
+  std::cout << "  --slaveof: " << FLAGS_slaveof << "\n";
+  std::cout << "  --usage: " << (FLAGS_usage ? "true" : "false") << "\n";
+  std::cout << "  --Version: " << (FLAGS_Version ? "true" : "false") << "\n";
+}
+
+static inline bool IsValidIPv4(const std::vector<std::string>& addrs) {
+  if (addrs.size() != 4) {
     return false;
   }
-  if (options_.GetConfigName().empty() && argc > 1 && argv[1] != nullptr) {
-    struct stat st {};
-    if (stat(argv[1], &st) == 0 && S_ISREG(st.st_mode) && ::access(argv[1], R_OK) == 0) {
-      options_.SetConfigName(argv[1]);
-      std::cerr << "Configuration file path: [" << argv[1] << "]\n";
-      argc = argc - 1;
-      argv = argv + 1;
+  for (const auto& s : addrs) {
+    if (s.empty() || s.length() > 3) {
+      return false;
+    }
+    for (const auto& c : s) {
+      if (!isdigit(c)) {
+        return false;
+      }
+    }
+    int x = stoi(s);
+    if (x < 0 || x > 255) {
+      return false;
+    }
+    if (s.length() > 1 && (s[0] == '0' || x == 0)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static inline bool IsValidIPv6(const std::vector<std::string>& addrs) {
+  //! TODO should impl the ipv6 check
+  return true;
+}
+
+static inline bool CheckIPAddress(const std::string& ip) {
+  // int cnt4 = 0, cnt6 = 0;
+  // for (const auto& c : ip) {
+  //   cnt4 += c == '.';
+  //   cnt6 += c == ':';
+  // }
+  // if (cnt4 && cnt6 || !cnt4 && !cnt6 || cnt4 != 3 && !cnt6 || cnt6 != 7 && !cnt4) {
+  //   return false;
+  // }
+  // std::vector<std::string> addrs = SplitIPs(ip, (cnt4 ? "." : "::"));
+  bool isv4 = ip.find('.') != std::string::npos;
+  bool isv6 = ip.find(':') != std::string::npos;
+  if (!isv4 && !isv6) {
+    return false;
+  }
+  std::vector<std::string> addrs = SplitIPs(ip, isv4 ? "." : "::");
+
+  if (isv4) {
+    return IsValidIPv4(addrs);
+  } else {
+    return IsValidIPv6(addrs);
+  }
+}
+
+bool KiwiDB::ParseArgs(int argc, char* argv[]) {
+  // 解析 gflags 参数
+  gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+
+  if (FLAGS_usage) {
+    return false;
+  }
+
+  if (FLAGS_Version) {
+    version();
+    exit(EXIT_SUCCESS);
+  }
+
+  // 设置解析的参数
+  if (!FLAGS_config.empty()) {
+    namespace fs = std::filesystem;
+    std::filesystem::path config_path(FLAGS_config);
+    if (fs::is_regular_file(config_path) &&
+        (fs::status(config_path).permissions() & fs::perms::owner_read) != fs::perms::none) {
+      options_.SetConfigName(FLAGS_config);
+      std::cerr << "Configuration file path: [" << FLAGS_config << "]\n";
     } else {
-      std::cerr << "Configuration file [" << argv[1] << "]: " << strerror(errno) << "\n";
+      std::cerr << "Configuration file [" << FLAGS_config << "]: " << strerror(errno) << "\n";
       return false;
     }
   } else {
     WarnDefaultConfig();
   }
-  while (true) {
-    int this_option_optind = optind ? optind : 1;
-    int option_index = 0;
-    int c;
-    c = getopt_long(argc, argv, "vhp:l:s:c", long_options, &option_index);
-    if (c == -1) {
-      break;
-    }
 
-    switch (c) {
-      case 'v': {
-        version();
-        std::exit(0);
-        break;
-      }
-      case 'h': {
-        Usage();
-        std::exit(0);
-        break;
-      }
-      case 'p': {
-        port_ = static_cast<uint16_t>(std::atoi(optarg));
-        break;
-      }
-      case 'l': {
-        options_.SetLogLevel(std::string(optarg));
-        break;
-      }
-      case 's': {
-        auto optarg_long = static_cast<unsigned int>(strlen(optarg));
-        char* str = static_cast<char*>(calloc(optarg_long, sizeof(char)));
-        if (str) {
-          if (sscanf(optarg, "%s:%hu", str, &master_port_) != 2) {
-            ERROR("Invalid slaveof format.");
-            free(str);
-            return false;
-          }
-          master_ = str;
-          free(str);
-        } else {
-          ERROR("Memory alloc failed.");
-        }
-        break;
-      }
-      case 'c': {
-        options_.SetRedisCompatibleMode(true);
-        break;
-      }
-      case '?': {
-        std::cerr << "Unknow option \n";
+  if (FLAGS_port > 0) {
+    if (FLAGS_port <= 1234) {
+      std::cerr << "You should have root privileges but now NOT support." << "\n";
+      return false;
+    }
+    port_ = static_cast<uint16_t>(FLAGS_port);
+  }
+
+  if (!FLAGS_loglevel.empty()) {
+    if (FLAGS_loglevel != "debug" && FLAGS_loglevel != "verbose" && FLAGS_loglevel != "notice" &&
+        FLAGS_loglevel != "warning") {
+      std::cerr << "You must be choose one of [debug, verbose, notice, warning]." << "\n";
+      return false;
+    }
+    options_.SetLogLevel(FLAGS_loglevel);
+  }
+
+  if (!FLAGS_slaveof.empty()) {
+    char str[256];
+    if (sscanf(FLAGS_slaveof.c_str(), "%[^:]:%hu", str, &master_port_) != 2) {
+      std::cerr << "Invalid slaveof format.\n";
+      return false;
+    }
+    master_ = str;
+  }
+
+  if (FLAGS_redis_compatible_mode) {
+    options_.SetRedisCompatibleMode(FLAGS_redis_compatible_mode);
+  }
+
+  if (!FLAGS_use_raft.empty()) {
+    std::transform(FLAGS_use_raft.cbegin(), FLAGS_use_raft.cend(), FLAGS_use_raft.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (FLAGS_use_raft != "yes" && FLAGS_use_raft != "no") {
+      std::cerr << "You should decide use-raft = yes or no" << "\n";
+      return false;
+    }
+    options_.SetUseRaft(FLAGS_use_raft);
+  }
+
+  if (!FLAGS_raft_ip.empty()) {
+    if (!CheckIPAddress(FLAGS_raft_ip)) {
+      std::cerr << "Invalid Raft IP address: " << FLAGS_raft_ip << "\n";
+      return false;
+    }
+    options_.SetRaftIp(FLAGS_raft_ip);
+  }
+
+  if (!FLAGS_ips.empty()) {
+    auto ips = SplitIPs(FLAGS_ips, " ");
+    for (const auto& ip : ips) {
+      if (!CheckIPAddress(ip)) {
+        std::cerr << "Invalid IP address: " << ip << "\n";
         return false;
-        break;
-      }
-      default: {
-        std::cerr << "Unknow option \n";
-        return false;
-        break;
       }
     }
+    options_.SetIps(ips);
   }
+
   return true;
 }
 
@@ -257,6 +357,14 @@ bool KiwiDB::Init() {
     g_config.Set("redis_compatible_mode", std::to_string(options_.GetRedisCompatibleMode()), true);
   }
 
+  if (!options_.GetUseRaft().empty()) {
+    g_config.Set("use-raft", "yes", true);
+  }
+
+  if (!options_.GetRaftIp().empty()) {
+    g_config.Set("raft-ip", options_.GetRaftIp(), true);
+  }
+
   auto num = g_config.worker_threads_num + g_config.slave_threads_num;
   options_.SetThreadNum(num);
 
@@ -285,6 +393,10 @@ bool KiwiDB::Init() {
   options_.SetRwSeparation(true);
 
   event_server_ = std::make_unique<net::EventServer<std::shared_ptr<PClient>>>(options_);
+
+  if (!options_.GetIps().empty()) {
+    g_config.ips = options_.GetIps();
+  }
 
   for (const auto& ip : g_config.ips) {
     net::SocketAddr addr(ip, g_config.port);
@@ -413,6 +525,7 @@ int main(int argc, char* argv[]) {
     Usage();
     return -1;
   }
+  PrintParsedFlags();
 
   if (!g_kiwi->GetConfigName().empty()) {
     if (!g_config.LoadFromFile(g_kiwi->GetConfigName())) {

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -69,7 +69,7 @@ static void Usage() {
   std::cerr << "kiwi is the kiwi server.\n";
   std::cerr << "\n";
   std::cerr << "Usage:\n";
-  std::cerr << "  kiwi [/path/to/kiwi.conf] [options]\n";
+  std::cerr << "  kiwi [--config] [/path/to/kiwi.conf] [options]\n";
   std::cerr << "\n";
   std::cerr << "Options:\n";
   std::cerr << "  -v, --Version                   output version information, then exit\n";
@@ -77,19 +77,19 @@ static void Usage() {
   std::cerr << "  -p PORT, --port PORT            Set the port to listen on\n";
   std::cerr << "  -l LEVEL, --loglevel LEVEL      Set the log level (e.g., info, debug, error)\n";
   std::cerr << "  -s ADDRESS, --slaveof ADDRESS   Set the slave address (e.g., 127.0.0.1:6380)\n";
-  std::cerr << "  -c, --redis_compatible_mode     Enable Redis compatibility mode\n";
-  std::cerr << "  --use_raft                      Whether to use Raft [yes or no]\n";
-  std::cerr << "  --raft_ip                       Raft IP address\n";
+  std::cerr << "  -c, --redis-compatible-mode     Enable Redis compatibility mode\n";
+  std::cerr << "  --use-raft                      Whether to use Raft [yes or no]\n";
+  std::cerr << "  --raft-ip                       Raft IP address\n";
   std::cerr << "  --ips                           List of IP addresses [x.x.x.x ::x::x::x::x ...]\n";
   std::cerr << "  --config                        Path to the configuration file\n";
   std::cerr << "Examples:\n";
-  std::cerr << "  kiwi --config /path/kiwi.conf\n";
-  std::cerr << "  kiwi --config /path/kiwi.conf --loglevel verbose\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf --loglevel verbose\n";
   std::cerr << "  kiwi --port 7777\n";
   std::cerr << "  kiwi --port 7777 --slaveof 127.0.0.1:8888\n";
-  std::cerr << "  kiwi --config /path/kiwi.conf --use_raft [yes or no]\n";
-  std::cerr << "  kiwi --config /path/kiwi.conf --ips [x.x.x.x ::x::x::x::x ...]\n";
-  std::cerr << "  kiwi --config /path/kiwi.conf --raft_ip x.x.x.x\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf --use_raft [yes or no]\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf --ips [x.x.x.x ::x::x::x::x ...]\n";
+  std::cerr << "  kiwi [--config] /path/kiwi.conf --raft_ip x.x.x.x\n";
 }
 
 static void version() {
@@ -126,18 +126,28 @@ static inline std::vector<std::string> SplitIPs(const std::string& ips, const st
 static inline void PrintParsedFlags() {
   std::cout << "Parsed command-line flags:\n";
   std::cout << "  --config: " << FLAGS_config << "\n";
-  std::cout << "  --use_raft: " << FLAGS_use_raft << "\n";
+  std::cout << "  --use-raft: " << FLAGS_use_raft << "\n";
   std::cout << "  --ips: " << FLAGS_ips << "\n";
-  std::cout << "  --raft_ip: " << FLAGS_raft_ip << "\n";
+  std::cout << "  --raft-ip: " << FLAGS_raft_ip << "\n";
   std::cout << "  --port: " << FLAGS_port << "\n";
   std::cout << "  --loglevel: " << FLAGS_loglevel << "\n";
-  std::cout << "  --redis_compatible_mode: " << (FLAGS_redis_compatible_mode ? "true" : "false") << "\n";
+  std::cout << "  --redis-compatible-mode: " << (FLAGS_redis_compatible_mode ? "true" : "false") << "\n";
   std::cout << "  --slaveof: " << FLAGS_slaveof << "\n";
   std::cout << "  --usage: " << (FLAGS_usage ? "true" : "false") << "\n";
   std::cout << "  --Version: " << (FLAGS_Version ? "true" : "false") << "\n";
 }
 
 bool KiwiDB::ParseArgs(int argc, char* argv[]) {
+  PString conf_file;
+  if (argc > 1 && !std::string(argv[1]).starts_with('-')) {
+    conf_file = argv[1];
+
+    for (int i = 1; i < argc; ++i) {
+      argv[i] = argv[i + 1];
+    }
+    argc--;
+  }
+
   gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
 
   if (FLAGS_usage) {
@@ -149,15 +159,20 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
     exit(EXIT_SUCCESS);
   }
 
+  // Overwrite the config
   if (!FLAGS_config.empty()) {
+    conf_file = FLAGS_config;
+  }
+
+  if (!conf_file.empty()) {
     namespace fs = std::filesystem;
-    std::filesystem::path config_path(FLAGS_config);
+    std::filesystem::path config_path(conf_file);
     if (fs::is_regular_file(config_path) &&
         (fs::status(config_path).permissions() & fs::perms::owner_read) != fs::perms::none) {
-      options_.SetConfigName(FLAGS_config);
-      std::cerr << "Configuration file path: [" << FLAGS_config << "]\n";
+      options_.SetConfigName(conf_file);
+      std::cerr << "Configuration file path: [" << conf_file << "]\n";
     } else {
-      std::cerr << "Configuration file [" << FLAGS_config << "]: " << strerror(errno) << "\n";
+      std::cerr << "Configuration file [" << conf_file << "]: " << strerror(errno) << "\n";
       return false;
     }
   } else {

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -137,61 +137,7 @@ static inline void PrintParsedFlags() {
   std::cout << "  --Version: " << (FLAGS_Version ? "true" : "false") << "\n";
 }
 
-static inline bool IsValidIPv4(const std::vector<std::string>& addrs) {
-  if (addrs.size() != 4) {
-    return false;
-  }
-  for (const auto& s : addrs) {
-    if (s.empty() || s.length() > 3) {
-      return false;
-    }
-    for (const auto& c : s) {
-      if (!isdigit(c)) {
-        return false;
-      }
-    }
-    int x = stoi(s);
-    if (x < 0 || x > 255) {
-      return false;
-    }
-    if (s.length() > 1 && (s[0] == '0' || x == 0)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-static inline bool IsValidIPv6(const std::vector<std::string>& addrs) {
-  //! TODO should impl the ipv6 check
-  return true;
-}
-
-static inline bool CheckIPAddress(const std::string& ip) {
-  // int cnt4 = 0, cnt6 = 0;
-  // for (const auto& c : ip) {
-  //   cnt4 += c == '.';
-  //   cnt6 += c == ':';
-  // }
-  // if (cnt4 && cnt6 || !cnt4 && !cnt6 || cnt4 != 3 && !cnt6 || cnt6 != 7 && !cnt4) {
-  //   return false;
-  // }
-  // std::vector<std::string> addrs = SplitIPs(ip, (cnt4 ? "." : "::"));
-  bool isv4 = ip.find('.') != std::string::npos;
-  bool isv6 = ip.find(':') != std::string::npos;
-  if (!isv4 && !isv6) {
-    return false;
-  }
-  std::vector<std::string> addrs = SplitIPs(ip, isv4 ? "." : "::");
-
-  if (isv4) {
-    return IsValidIPv4(addrs);
-  } else {
-    return IsValidIPv6(addrs);
-  }
-}
-
 bool KiwiDB::ParseArgs(int argc, char* argv[]) {
-  // 解析 gflags 参数
   gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
 
   if (FLAGS_usage) {
@@ -203,7 +149,6 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
     exit(EXIT_SUCCESS);
   }
 
-  // 设置解析的参数
   if (!FLAGS_config.empty()) {
     namespace fs = std::filesystem;
     std::filesystem::path config_path(FLAGS_config);
@@ -260,21 +205,11 @@ bool KiwiDB::ParseArgs(int argc, char* argv[]) {
   }
 
   if (!FLAGS_raft_ip.empty()) {
-    if (!CheckIPAddress(FLAGS_raft_ip)) {
-      std::cerr << "Invalid Raft IP address: " << FLAGS_raft_ip << "\n";
-      return false;
-    }
     options_.SetRaftIp(FLAGS_raft_ip);
   }
 
   if (!FLAGS_ips.empty()) {
     auto ips = SplitIPs(FLAGS_ips, " ");
-    for (const auto& ip : ips) {
-      if (!CheckIPAddress(ip)) {
-        std::cerr << "Invalid IP address: " << ip << "\n";
-        return false;
-      }
-    }
     options_.SetIps(ips);
   }
 

--- a/src/options.h
+++ b/src/options.h
@@ -29,11 +29,26 @@ class Options : public net::NetOptions {
 
   bool GetRedisCompatibleMode() const { return redis_compatible_mode; }
 
+  void SetIps(const std::vector<PString>& ips) { ips_ = ips; }
+
+  const std::vector<PString>& GetIps() const { return ips_; }
+
+  void SetUseRaft(const PString& use) { use_raft = use; }
+
+  const PString& GetUseRaft() const { return use_raft; }
+
+  void SetRaftIp(const PString& ip) { raft_ip = ip; }
+
+  const PString& GetRaftIp() const { return raft_ip; }
+
  private:
   PString cfg_file_;
   PString log_level_;
 
   std::atomic<bool> redis_compatible_mode = false;
+  std::vector<PString> ips_;
+  PString use_raft;
+  PString raft_ip;
 };
 
 }  // namespace kiwi

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -213,8 +213,8 @@ proc start_server {options {code undefined}} {
     if {$::valgrind} {
         set pid [exec valgrind --suppressions=src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full src/redis-server $config_file > $stdout 2> $stderr &]
     } else {
-        #set pid [exec src/redis-server -c $config_file > $stdout 2> $stderr &]
-        set pid [exec src/redis-server $config_file > $stdout 2> $stderr &]
+        #set pid [exec src/redis-server --config $config_file > $stdout 2> $stderr &]
+        set pid [exec src/redis-server --config $config_file > $stdout 2> $stderr &]
     }
 
     puts "Starting ---- port = ${::port}"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -214,7 +214,7 @@ proc start_server {options {code undefined}} {
         set pid [exec valgrind --suppressions=src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full src/redis-server $config_file > $stdout 2> $stderr &]
     } else {
         #set pid [exec src/redis-server --config $config_file > $stdout 2> $stderr &]
-        set pid [exec src/redis-server --config $config_file > $stdout 2> $stderr &]
+        set pid [exec src/redis-server $config_file > $stdout 2> $stderr &]
     }
 
     puts "Starting ---- port = ${::port}"


### PR DESCRIPTION
Support Cmd:
 
related issue https://github.com/arana-db/kiwi/issues/215

- kiwi --config /path/conf
- kiwi --Version
- kiwi --usage (original help command)
- kiwi --port port
- kiwi --loglevel level
- kiwi --slaveof addr
- kiwi --redis_compatible_mode
- kiwi --use_raft yes/no
- kiwi --raft_ip ip
- kiwi --ips [x.x.x.x ::x::x::x::x ...]

**All options support validity checks, EXCEPT for IPV6, which supports incomplete validity checks**.

**NOT SUPPORT THE SHORT COMMAND**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced new command-line options enabling users to toggle Raft usage, specify a list of IP addresses, and set a dedicated Raft IP.
  - Added a command for displaying usage information for the Kiwi application.

- **Bug Fixes**
  - Corrected the command used to start the Redis server by replacing the outdated `-c` flag with the `--config` flag.

- **Refactor**
  - Enhanced argument parsing and validation for a more robust and streamlined configuration experience.
  - Improved handling of configuration settings related to IP addresses and Raft usage.
  - Updated documentation to clarify command-line options for running the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->