### PR TITLE
fix: clusterdown errcode

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -9,15 +9,12 @@
 
 #include "base_cmd.h"
 
-#include "fmt/core.h"
-
 #include "raft/raft.h"
 
 #include "common.h"
 #include "config.h"
 #include "kiwi.h"
 #include "log.h"
-#include "raft/raft.h"
 
 namespace kiwi {
 
@@ -51,7 +48,7 @@ void BaseCmd::Execute(PClient* client) {
     if (!RAFT_INST.IsLeader()) {
       auto leader_addr = RAFT_INST.GetLeaderAddress();
       if (leader_addr.empty()) {
-        client->SetRes(CmdRes::kErrOther, std::string("-CLUSTERDOWN No Raft leader"));
+        client->SetRes(CmdRes::kErrClusterDown, "No raft leader");
         return;
       }
 

--- a/src/resp/resp2_encode.cc
+++ b/src/resp/resp2_encode.cc
@@ -77,6 +77,8 @@ void Resp2Encode::SetRes(CmdRes ret, const std::string& content) {
       break;
     case CmdRes::kErrMoved:
       AppendStringRaw(fmt::format("-MOVED {}\r\n", content));
+    case CmdRes::kErrClusterDown:
+      AppendStringRaw(fmt::format("-CLUSTERDOWN {}\r\n", content));
       break;
     case CmdRes::KIncrByOverFlow:
       AppendStringRaw(fmt::format("-ERR increment would produce NaN or Infinity {}\r\n", content));

--- a/src/resp/resp_encode.h
+++ b/src/resp/resp_encode.h
@@ -33,6 +33,7 @@ enum class CmdRes : std::int8_t {
   kInconsistentHashTag,
   kErrOther,
   kErrMoved,
+  kErrClusterDown,
   kUnknownCmd,
   kUnknownSubCmd,
   KIncrByOverFlow,


### PR DESCRIPTION
-CLUSTERDOWN而不是-ERR -CLUSTERDOWN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined error responses to clearly indicate when cluster operations fail due to leader unavailability.
	- Simplified the messaging for cluster down events to enhance clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->