### PR TITLE
fix: syntax errcode

### DIFF
--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -258,7 +258,7 @@ void HelloCmd::DoCmd(PClient* client) {
       }
       next_arg += 2;
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "Syntax error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameHello);
       return;
     }
   }
@@ -336,7 +336,7 @@ bool InfoCmd::DoInitial(PClient* client) {
       return false;
     }
   } else {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameInfo);
     return false;
   }
   return true;
@@ -603,7 +603,7 @@ bool SortCmd::DoInitial(PClient* client) {
     } else if (strcasecmp(client->argv_[i].data(), "limit") == 0 && leftargs >= 2) {
       if (kstd::String2int(client->argv_[i + 1], &offset_) == 0 ||
           kstd::String2int(client->argv_[i + 2], &count_) == 0) {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameSort);
         return false;
       }
       i += 2;
@@ -620,7 +620,7 @@ bool SortCmd::DoInitial(PClient* client) {
       get_patterns_.push_back(client->argv_[i + 1]);
       i++;
     } else {
-      client->SetRes(CmdRes::kSyntaxErr);
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSort);
       return false;
     }
   }

--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -74,7 +74,7 @@ void HGetCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "hget cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameHGet);
   }
 }
 
@@ -419,7 +419,7 @@ void HSetNXCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "hsetnx cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameHSetNX);
   }
 }
 
@@ -476,12 +476,12 @@ void HRandFieldCmd::DoCmd(PClient* client) {
       return;
     }
     if (argv.size() > 4) {
-      client->SetRes(CmdRes::kSyntaxErr);
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameHRandField);
       return;
     }
     if (argv.size() > 3) {
       if (kWithValueString != kstd::StringToLower(argv[3])) {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameHRandField);
         return;
       }
       with_values = true;

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -39,7 +39,7 @@ void GetCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "get key error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameGet);
   }
 }
 
@@ -66,7 +66,7 @@ bool SetCmd::DoInitial(PClient* client) {
       condition_ = (condition_ == SetCmd::kNONE) ? SetCmd::kEXORPX : condition_;
       index++;
       if (index == argv_.size()) {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameSet);
         return false;
       }
       if (kstd::String2int(argv_[index].data(), argv_[index].size(), &sec_) == 0) {
@@ -78,7 +78,7 @@ bool SetCmd::DoInitial(PClient* client) {
         sec_ /= 1000;
       }
     } else {
-      client->SetRes(CmdRes::kSyntaxErr);
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSet);
       return false;
     }
     index++;
@@ -312,7 +312,7 @@ bool BitOpCmd::DoInitial(PClient* client) {
         kstd::StringEqualCaseInsensitive(client->argv_[1], "or") ||
         kstd::StringEqualCaseInsensitive(client->argv_[1], "not") ||
         kstd::StringEqualCaseInsensitive(client->argv_[1], "xor"))) {
-    client->SetRes(CmdRes::kSyntaxErr, "operation error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameBitOp);
     return false;
   }
   return true;
@@ -347,7 +347,7 @@ void BitOpCmd::DoCmd(PClient* client) {
   }
 
   if (err != kPErrorOK) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameBitOp);
   } else {
     PString value;
     int64_t result_length = 0;

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -9,6 +9,7 @@
 
 #include "cmd_list.h"
 #include "src/scope_record_lock.h"
+#include "base_cmd.h"
 #include "std_string.h"
 #include "store.h"
 
@@ -32,7 +33,7 @@ void LPushCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "lpush cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameLPush);
   }
 }
 
@@ -103,7 +104,7 @@ void RPushCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "rpush cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameRPush);
   }
 }
 
@@ -169,7 +170,7 @@ void RPopCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "rpop cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameRPop);
   }
 }
 
@@ -248,7 +249,7 @@ void LRangeCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "lrange cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameLRange);
     }
     return;
   }
@@ -307,7 +308,7 @@ void LTrimCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "ltrim cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameLTrim);
   }
 }
 
@@ -341,7 +342,7 @@ void LSetCmd::DoCmd(PClient* client) {
     } else if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "lset cmd error");  // just a safeguard
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameLSet);  // just a safeguard
     }
   } else {
     client->SetRes(CmdRes::kInvalidInt);
@@ -373,7 +374,7 @@ void LInsertCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "linsert cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameLInsert);
     }
     return;
   }

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -8,8 +8,8 @@
  */
 
 #include "cmd_list.h"
-#include "src/scope_record_lock.h"
 #include "base_cmd.h"
+#include "src/scope_record_lock.h"
 #include "std_string.h"
 #include "store.h"
 

--- a/src/cmd_set.cc
+++ b/src/cmd_set.cc
@@ -10,6 +10,7 @@
 #include "cmd_set.h"
 #include <memory>
 #include <utility>
+#include "base_cmd.h"
 #include "std/std_string.h"
 #include "store.h"
 
@@ -52,7 +53,7 @@ void SAddCmd::DoCmd(PClient* client) {
   } else if (s.IsInvalidArgument()) {
     client->SetRes(CmdRes::kMultiKey);
   } else {
-    client->SetRes(CmdRes::kSyntaxErr, "sadd cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameSAdd);
   }
 }
 
@@ -77,7 +78,7 @@ void SUnionStoreCmd::DoCmd(PClient* client) {
       client->SetRes(CmdRes::kMultiKey);
       return;
     }
-    client->SetRes(CmdRes::kSyntaxErr, "sunionstore cmd error");
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameSUnionStore);
   }
   client->AppendInteger(ret);
 }
@@ -172,7 +173,7 @@ void SInterStoreCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "sinterstore cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSInterStore);
     }
     return;
   }
@@ -193,7 +194,7 @@ void SCardCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "scard cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSCard);
     }
     return;
   }
@@ -201,7 +202,7 @@ void SCardCmd::DoCmd(PClient* client) {
     client->AppendInteger(reply_Num);
     return;
   }
-  client->SetRes(CmdRes::kSyntaxErr, "scard cmd error");
+  client->SetRes(CmdRes::kSyntaxErr, kCmdNameSCard);
 }
 
 SMoveCmd::SMoveCmd(const std::string& name, int16_t arity)
@@ -261,7 +262,7 @@ void SRandMemberCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "srandmember cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSRandMember);
     }
     return;
   }
@@ -287,7 +288,7 @@ void SPopCmd::DoCmd(PClient* client) {
       if (s.IsInvalidArgument()) {
         client->SetRes(CmdRes::kMultiKey);
       } else {
-        client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameSPop);
       }
       return;
     }
@@ -306,7 +307,7 @@ void SPopCmd::DoCmd(PClient* client) {
       if (s.IsInvalidArgument()) {
         client->SetRes(CmdRes::kMultiKey);
       } else {
-        client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameSPop);
       }
       return;
     }
@@ -334,7 +335,7 @@ void SMembersCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "smembers cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSMembers);
     }
     return;
   }
@@ -357,7 +358,7 @@ void SDiffCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "sdiff cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSDiff);
     }
     return;
   }
@@ -383,7 +384,7 @@ void SDiffstoreCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "sdiffstore cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameSDiffstore);
     }
     return;
   }
@@ -395,7 +396,7 @@ SScanCmd::SScanCmd(const std::string& name, int16_t arity)
 
 bool SScanCmd::DoInitial(PClient* client) {
   if (auto size = client->argv_.size(); size != 3 && size != 5 && size != 7) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameSScan);
     return false;
   }
   client->SetKey(client->argv_[1]);

--- a/src/cmd_zset.cc
+++ b/src/cmd_zset.cc
@@ -11,6 +11,7 @@
 
 #include <memory>
 
+#include "base_cmd.h"
 #include "std/std_string.h"
 #include "store.h"
 
@@ -95,7 +96,7 @@ bool ZAddCmd::DoInitial(PClient* client) {
 void ZAddCmd::DoCmd(PClient* client) {
   size_t argc = client->argv_.size();
   if (argc % 2 == 1) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZAdd);
     return;
   }
   score_members_.clear();
@@ -221,7 +222,7 @@ bool ZsetUIstoreParentCmd::DoInitial(PClient* client) {
   }
   auto argc = argv_.size();
   if (argc < num_keys_ + 3) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZInterstore + "/" + kCmdNameZUnionstore);
     return false;
   }
   keys_.assign(argv_.begin() + 3, argv_.begin() + 3 + num_keys_);
@@ -231,7 +232,7 @@ bool ZsetUIstoreParentCmd::DoInitial(PClient* client) {
     if (strcasecmp(argv_[index].data(), "weights") == 0) {
       index++;
       if (argc < index + num_keys_) {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZInterstore + "/" + kCmdNameZUnionstore);
         return false;
       }
       double weight;
@@ -246,7 +247,7 @@ bool ZsetUIstoreParentCmd::DoInitial(PClient* client) {
     } else if (strcasecmp(argv_[index].data(), "aggregate") == 0) {
       index++;
       if (argc < index + 1) {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZInterstore + "/" + kCmdNameZUnionstore);
         return false;
       }
       if (strcasecmp(argv_[index].data(), "sum") == 0) {
@@ -256,12 +257,12 @@ bool ZsetUIstoreParentCmd::DoInitial(PClient* client) {
       } else if (strcasecmp(argv_[index].data(), "max") == 0) {
         aggregate_ = storage::MAX;
       } else {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZInterstore + "/" + kCmdNameZUnionstore);
         return false;
       }
       index++;
     } else {
-      client->SetRes(CmdRes::kSyntaxErr);
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameZInterstore + "/" + kCmdNameZUnionstore);
       return false;
     }
   }
@@ -322,7 +323,7 @@ void ZRevrangeCmd::DoCmd(PClient* client) {
   if (client->argv_.size() == 5 && (strcasecmp(client->argv_[4].data(), "withscores") == 0)) {
     is_ws = true;
   } else if (client->argv_.size() != 4) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRevrange);
     return;
   }
   if (kstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &start) == 0) {
@@ -386,7 +387,7 @@ void ZRangebyscoreCmd::DoCmd(PClient* client) {
         with_scores = true;
       } else if (strcasecmp(client->argv_[index].data(), "limit") == 0) {
         if (index + 3 > argc) {
-          client->SetRes(CmdRes::kSyntaxErr);
+          client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRangebyscore);
           return;
         }
         index++;
@@ -400,7 +401,7 @@ void ZRangebyscoreCmd::DoCmd(PClient* client) {
           return;
         }
       } else {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRangebyscore);
         return;
       }
       index++;
@@ -504,7 +505,7 @@ void ZRevrangebyscoreCmd::DoCmd(PClient* client) {
         with_scores = true;
       } else if (strcasecmp(client->argv_[index].data(), "limit") == 0) {
         if (index + 3 > argc) {
-          client->SetRes(CmdRes::kSyntaxErr);
+          client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRevrangebyscore);
           return;
         }
         index++;
@@ -518,7 +519,7 @@ void ZRevrangebyscoreCmd::DoCmd(PClient* client) {
           return;
         }
       } else {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRevrangebyscore);
         return;
       }
       index++;
@@ -579,7 +580,7 @@ void ZCardCmd::DoCmd(PClient* client) {
     if (s.IsInvalidArgument()) {
       client->SetRes(CmdRes::kMultiKey);
     } else {
-      client->SetRes(CmdRes::kSyntaxErr, "ZCard cmd error");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameZCard);
     }
     return;
   }
@@ -618,7 +619,7 @@ void ZRangeCmd::DoCmd(PClient* client) {
         with_scores = true;
       } else if (strcasecmp(client->argv_[index].data(), "limit") == 0) {
         if (index + 3 > argc) {
-          client->SetRes(CmdRes::kSyntaxErr);
+          client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRange);
           return;
         }
         index++;
@@ -632,14 +633,14 @@ void ZRangeCmd::DoCmd(PClient* client) {
           return;
         }
       } else {
-        client->SetRes(CmdRes::kSyntaxErr);
+        client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRange);
         return;
       }
       index++;
     }
   }
   if (by_score && by_lex) {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRange);
     return;
   }
 
@@ -705,7 +706,7 @@ void ZRangeCmd::DoCmd(PClient* client) {
   size_t m_end = offset + count;
   if (by_lex) {
     if (with_scores) {
-      client->SetRes(CmdRes::kSyntaxErr, "by lex not support with scores");
+      client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRange);
     } else {
       client->AppendArrayLen(count);
       for (; m_start < m_end; m_start++) {
@@ -784,7 +785,7 @@ void ZRangebylexCmd::DoCmd(PClient* client) {
     }
   } else if (argc == 4) {
   } else {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRangebylex);
     return;
   }
 
@@ -848,7 +849,7 @@ void ZRevrangebylexCmd::DoCmd(PClient* client) {
     }
   } else if (argc == 4) {
   } else {
-    client->SetRes(CmdRes::kSyntaxErr);
+    client->SetRes(CmdRes::kSyntaxErr, kCmdNameZRevrangebylex);
     return;
   }
 

--- a/src/resp/resp2_encode.cc
+++ b/src/resp/resp2_encode.cc
@@ -17,7 +17,7 @@ void Resp2Encode::SetRes(CmdRes ret, const std::string& content) {
       SetLineString("+PONG");
       break;
     case CmdRes::kSyntaxErr:
-      AppendStringRaw(fmt::format("-ERR syntax error\r\n", content));
+      AppendStringRaw(fmt::format("-ERR syntax error command '{}'\r\n", content));
       break;
     case CmdRes::kUnknownCmd:
       AppendStringRaw(fmt::format("-ERR unknown command '{}'\r\n", content));

--- a/src/resp/resp2_encode.cc
+++ b/src/resp/resp2_encode.cc
@@ -17,7 +17,7 @@ void Resp2Encode::SetRes(CmdRes ret, const std::string& content) {
       SetLineString("+PONG");
       break;
     case CmdRes::kSyntaxErr:
-      SetLineString("-ERR syntax error");
+      AppendStringRaw(fmt::format("-ERR syntax error\r\n", content));
       break;
     case CmdRes::kUnknownCmd:
       AppendStringRaw(fmt::format("-ERR unknown command '{}'\r\n", content));


### PR DESCRIPTION
有时候会报Syntax Error，但是不说哪个命令出现了Error，不方便调试.
之前是有的命令加上了，有的命令没有.
我将Syntax Error后都加上了命令名，统一一下。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messages for various commands so that they now provide specific, context-aware feedback when syntax issues occur.
	- Standardized error responses across the app, making it easier for users to identify and resolve input mistakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->