### PR TITLE
fix: return nil when brpop / brlpop cmd timeout 

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -150,6 +150,7 @@ class PClient : public std::enable_shared_from_this<PClient> {
   void AppendString(const char* value, int64_t size) { resp_encode_->AppendString(value, size); }
   void SetLineString(const std::string& value) { resp_encode_->SetLineString(value); }
   void Reply(std::string& str) { resp_encode_->Reply(str); }
+  void ReplyNull() { AppendStringRaw("*-1\r\n"); }
   // reply
 
   // pubsub

--- a/src/kiwi.cc
+++ b/src/kiwi.cc
@@ -202,7 +202,7 @@ void KiwiDB::ScanEvictedBlockedConnsOfBlrpop() {
         conn_node = conns_list->erase(conn_node);
         CleanBlockedNodes(conn_ptr);
       } else if (conn_node->IsExpired()) {
-        conn_ptr->AppendString("");
+        conn_ptr->ReplyNull();
         conn_ptr->SendPacket();
         conn_node = conns_list->erase(conn_node);
         CleanBlockedNodes(conn_ptr);


### PR DESCRIPTION
问题：brpop / blpop命令超时会返回空字符串，会导致go-redis等客户端解析错误  
改动：将超时返回修改为：*-1/r/n , 与redis保持一致  

redis在执行brpop / blpop命令超时会返回逻辑如下：
![redis-brpop-timeout-reply=1](https://github.com/user-attachments/assets/d8704a72-7ed6-43e0-b76e-c2a2fd334129)
![redis-brpop-timeout-reply=2](https://github.com/user-attachments/assets/96a0d6b2-b47a-49f0-9387-4ae6e6a5d87f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced response handling so that operations now return a clear "empty" reply when no valid result is available, offering users more consistent feedback in scenarios where connections have expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->