### PR TITLE
fix: zadd command override rather than ignore the same member in one times

### DIFF
--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -167,11 +167,11 @@ Status Redis::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_membe
   uint32_t statistic = 0;
   std::unordered_map<std::string, double> ms_map;
   std::vector<ScoreMember> filtered_score_members;
-  for (const auto& sm : score_members) {
-    ms_map[sm.member] = sm.score;
-  }
-  for (auto& [member, score] : ms_map) {
-    filtered_score_members.emplace_back(score, std::move(member));
+  for (auto it = score_members.rbegin(); it != score_members.rend(); ++it) {
+    auto& sm = *it;
+    if (ms_map.emplace(sm.member, sm.score).second) {
+      filtered_score_members.emplace_back(sm.score, sm.member);
+    }
   }
 
   char score_buf[8];

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -165,13 +165,13 @@ Status Redis::ZPopMin(const Slice& key, const int64_t count, std::vector<ScoreMe
 Status Redis::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_members, int32_t* ret) {
   *ret = 0;
   uint32_t statistic = 0;
-  std::unordered_set<std::string> unique;
+  std::unordered_map<std::string, double> ms_map;
   std::vector<ScoreMember> filtered_score_members;
   for (const auto& sm : score_members) {
-    if (unique.find(sm.member) == unique.end()) {
-      unique.insert(sm.member);
-      filtered_score_members.push_back(sm);
-    }
+    ms_map[sm.member] = sm.score;
+  }
+  for (auto& [member, score] : ms_map) {
+    filtered_score_members.emplace_back(score, std::move(member));
   }
 
   char score_buf[8];


### PR DESCRIPTION
fix #236 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of duplicate members in sorted sets to retain the last occurrence.
	- Enhanced internal processing for better performance while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->